### PR TITLE
Complex navigator backend changes

### DIFF
--- a/src/app/complex/complex-results/complex-navigator/complex-navigator.component.html
+++ b/src/app/complex/complex-results/complex-navigator/complex-navigator.component.html
@@ -1,5 +1,5 @@
 <div>
   <cp-table-structure [complexSearch]="complexSearch"
-                      [components]="components">
+                      [interactors]="interactors">
   </cp-table-structure>
 </div>

--- a/src/app/complex/complex-results/complex-navigator/complex-navigator.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/complex-navigator.component.ts
@@ -11,7 +11,7 @@ import {Router} from '@angular/router';
 })
 export class ComplexNavigatorComponent implements OnInit {
   @Input() complexSearch: ComplexSearchResult;
-  _components: Set<Interactor>;
+  _interactors: Set<Interactor>;
 
   constructor(private router: Router) {
   }
@@ -19,12 +19,12 @@ export class ComplexNavigatorComponent implements OnInit {
   ngOnInit() {
   }
 
-  get components(): Set<Interactor> {
-    return this._components;
+  get interactors(): Set<Interactor> {
+    return this._interactors;
   }
 
   @Input()
-  set components(value: Set<Interactor>) {
-    this._components = value;
+  set interactors(value: Set<Interactor>) {
+    this._interactors = value;
   }
 }

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.html
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.html
@@ -1,7 +1,7 @@
 <div class="Complex-navigator">
   <table class="interactors-table">
     <!-- Interactors' column -->
-    <ng-container *ngFor="let interactor of components; let i=index">
+    <ng-container *ngFor="let interactor of interactors; let i=index">
       <ng-container>
         <tr>
           <td>
@@ -41,7 +41,7 @@
                 {{ (stochiometryOfInteractors(complex, interactor.identifier)) }}
               </div>
               <div class="verticalLineBottom"
-                   *ngIf="(stochiometryOfInteractors(complex, interactor.id)) != null">.
+                   *ngIf="(stochiometryOfInteractors(complex, interactor.identifier)) != null">.
               </div>
               <div class="verticalLineTop"
                    *ngIf="stoichiometryOfInteractorsMainTable(complex, interactor, complexSearch.elements)">.
@@ -69,7 +69,7 @@
                 <a [routerLink]="['/complex/search']"
                    [queryParams]="{query: el.identifier, page: 1}"
                    target="_blank">
-                  {{ el.interactorName }}
+                  {{ el.name }}
                   <i class="{{interactorTypeIcon(el)}}" title="{{interactor.interactorType}}"></i>
                   <i class="icon icon-functional small" data-icon="1"
                      title="More complexes containing this interactor"></i>
@@ -84,7 +84,7 @@
             <ng-container *ngFor="let complex of complexSearch.elements">
               <td style="background: #b7b8b8;">
                 <div class="verticalLineTop"
-                     *ngIf="stochiometryOfInteractors(complex, el.id) || stoichiometryOfInteractorsExpandable(complex, el)">
+                     *ngIf="stochiometryOfInteractors(complex, el.identifier) || stoichiometryOfInteractorsExpandable(complex, el)">
                   .
                 </div>
                 <div class="stoichNum"
@@ -94,7 +94,7 @@
                   {{ stoichiometryOfInteractorsExpandable(complex, el) }}
                 </div>
                 <div class="verticalLineBottom"
-                     *ngIf="stochiometryOfInteractors(complex, el.id) || stoichiometryOfInteractorsExpandable(complex, el)">
+                     *ngIf="stochiometryOfInteractors(complex, el.identifier) || stoichiometryOfInteractorsExpandable(complex, el)">
                   .
                 </div>
               </td>

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.html
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.html
@@ -33,7 +33,7 @@
           <!-- Interactors' stoichiometry -->
           <ng-container *ngFor="let complex of complexSearch.elements">
             <td>
-              <ng-container *ngIf="stochiometryOfInteractors(complex, interactor.interactor.identifier) != null">
+              <ng-container *ngIf="!!findInteractorInComplex(complex, interactor.interactor.identifier)">
                 <div class="verticalLineTop">.
                 </div>
                 <div class="stoichNum" title="{{ getStochiometry(complex, interactor.interactor.identifier) }}">
@@ -42,16 +42,13 @@
                 <div class="verticalLineBottom">.
                 </div>
               </ng-container>
-              <ng-container *ngIf="stoichiometryOfInteractorsMainTable(complex, interactor.interactor, complexSearch.elements)">
+              <ng-container class="stoichComponent" *ngIf="findInteractorsInSubComplex(complex, interactor.interactor.identifier).length > 0">
                 <div class="verticalLineTop">.
                 </div>
-                <ng-container class="stoichComponent">
-                  <!-- subcomplexes' interactors' stoichiometry -->
-                  <div class="stoichNum"
-                       title="{{ getStoichiometrySubComplex(complex, interactor.interactor, complexSearch.elements) }}">
-                    {{ stoichiometryOfInteractorsMainTable(complex, interactor.interactor, complexSearch.elements) }}
-                  </div>
-                </ng-container>
+                <!-- subcomplexes' interactors' stoichiometry -->
+                <div class="stoichNum" title="{{ getStoichiometrySubComplex(complex, interactor.interactor.identifier) }}">
+                  {{ stoichiometryOfInteractorsMainTable(complex, interactor.interactor.identifier) }}
+                </div>
                 <div class="verticalLineBottom">.
                 </div>
               </ng-container>
@@ -60,48 +57,54 @@
         </tr>
         <!-- Expandable menu for subcomplexes -->
         <ng-container *ngIf="interactor.expanded">
-          <tr *ngFor="let el of (componentToComplex(interactor.interactor, complexSearch.elements)).components">
-            <!-- Create an error when the components are not in the search results -->
-            <td style="background: #b7b8b8">
-              <div style="font-weight: bold">
-                <a [routerLink]="['/complex/search']"
-                   [queryParams]="{query: el.identifier, page: 1}"
-                   target="_blank">
-                  {{ el.name }}
-                  <i class="{{interactorTypeIcon(el)}}" title="{{interactor.interactor.interactorType}}"></i>
-                  <i class="icon icon-functional small" data-icon="1"
-                     title="More complexes containing this interactor"></i>
-                </a>
-              </div>
-              <div *ngIf="showExternalLink(el)" class="interactorType">
-                <a href="{{el.identifierLink}}" target="_blank">{{ el.identifier }}
-                  <i class="icon icon-generic small" data-icon="x" title="More information"></i>
-                </a>
-              </div>
-            </td>
-            <ng-container *ngFor="let complex of complexSearch.elements">
-              <td style="background: #b7b8b8;">
-                <ng-container *ngIf="stochiometryOfInteractors(complex, el.identifier)">
-                  <div class="verticalLineTop">.
-                  </div>
-                  <div class="stoichNum" title="{{ (getStochiometry(complex, el.identifier)) }}">
-                    {{ stochiometryOfInteractors(complex, el.identifier) }}
-                  </div>
-                  <div class="verticalLineBottom">.
-                  </div>
-                </ng-container>
-                <ng-container *ngIf="stoichiometryOfInteractorsExpandable(complex, el)">
-                  <div class="verticalLineTop">.
-                  </div>
-                  <div class="stoichNum" title="{{ (getStochiometry(complex, el.identifier)) }}">
-                    {{ stoichiometryOfInteractorsExpandable(complex, el) }}
-                  </div>
-                  <div class="verticalLineBottom">.
-                  </div>
-                </ng-container>
+          <ng-container *ngIf="!!interactor.subComponents">
+            <tr *ngFor="let el of interactor.subComponents">
+              <!-- Create an error when the components are not in the search results -->
+              <td style="background: #7e9394">
+                <div style="font-weight: bold">
+                  <a [routerLink]="['/complex/search']"
+                     [queryParams]="{query: el.identifier, page: 1}"
+                     target="_blank">
+                    {{ el.name }}
+                    <i class="{{interactorTypeIcon(el)}}" title="{{interactor.interactor.interactorType}}"></i>
+                    <i class="icon icon-functional small" data-icon="1"
+                       title="More complexes containing this interactor"></i>
+                  </a>
+                </div>
+                <div *ngIf="showExternalLink(el)" class="interactorType">
+                  <a href="{{el.identifierLink}}" target="_blank">{{ el.identifier }}
+                    <i class="icon icon-generic small" data-icon="x" title="More information"></i>
+                  </a>
+                </div>
               </td>
-            </ng-container>
-          </tr>
+              <ng-container *ngFor="let complex of complexSearch.elements">
+                <td style="background: #7e9394;">
+                  <ng-container *ngIf="!!findInteractorInComplex(complex, el.identifier)">
+                    <div class="verticalLineTop">.
+                    </div>
+                    <div class="stoichNum"
+                         title="{{ getStochiometry(complex, el.identifier) }}">
+                      {{ stochiometryOfInteractors(complex, el.identifier) }}
+                    </div>
+                    <div class="verticalLineBottom">.
+                    </div>
+                  </ng-container>
+                  <ng-container
+                    *ngIf="!!findInteractorInExpandedSubComplex(interactor, complex, el.identifier)">
+                    <!-- subcomplexes' interactors' stoichiometry -->
+                    <div class="verticalLineTop">.
+                    </div>
+                    <div class="stoichNum"
+                         title="{{ getStochiometryInExpandedSubComplex(interactor, el.identifier) }}">
+                      {{ stoichiometryOfInteractorsExpandable(interactor, el.identifier) }}
+                    </div>
+                    <div class="verticalLineBottom">.
+                    </div>
+                  </ng-container>
+                </td>
+              </ng-container>
+            </tr>
+          </ng-container>
         </ng-container>
       </ng-container>
     </ng-container>

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.html
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.html
@@ -1,31 +1,31 @@
 <div class="Complex-navigator">
   <table class="interactors-table">
     <!-- Interactors' column -->
-    <ng-container *ngFor="let interactor of enrichedInteractors; let i=index">
+    <ng-container *ngFor="let interactor of components; let i=index">
       <ng-container>
-        <tr *ngIf="!interactor.hidden">
+        <tr>
           <td>
             <div style="font-weight: bold">
-              {{ interactor.interactor.name }}
-              <i class="{{interactorTypeIcon(interactor.interactor)}}" title="{{interactor.interactor.interactorType}}"></i>
+              {{ interactor.name }}
+              <i class="{{interactorTypeIcon(interactor)}}" title="{{interactor.interactorType}}"></i>
               <!-- Adding of the icons to access details of the interactor -->
               <a [routerLink]="['/complex/search']"
-                 [queryParams]="{query: interactor.interactor.identifier, page: 1}"
+                 [queryParams]="{query: interactor.identifier, page: 1}"
                  target="_blank">
                 <i class="icon icon-functional small" data-icon="1"
                    title="Complexes containing this interactor"></i>
               </a>
             </div>
             <!-- Icon for the expandable -->
-            <div class="container" *ngIf="interactor.isSubComplex">
-              {{ interactor.interactor.identifier }}
-              <a title="{{ interactor.interactor.name }}'s interactors" (click)="toggleSubcomplexExpandable(i)">
+            <div class="container" *ngIf="isComponentASubcomplex(interactor);">
+              {{ interactor.identifier }}
+              <a title="{{ interactor.name }}'s interactors" (click)="toggleSubcomplexExpandable(i)">
                 <i class="icon icon-common" data-icon="&#xf078;"
                    style="font-size:small; margin-top: 2px"></i>
               </a>
             </div>
-            <div *ngIf="showExternalLink(interactor.interactor)" class="interactorType">
-              <a href="{{interactor.interactor.identifierLink}}" target="_blank">{{ interactor.interactor.identifier }}
+            <div *ngIf="showExternalLink(interactor)" class="interactorType">
+              <a href="{{interactor.identifierLink}}" target="_blank">{{ interactor.identifier }}
                 <i class="icon icon-generic small" data-icon="x"></i>
               </a>
             </div>
@@ -33,79 +33,73 @@
           <!-- Interactors' stoichiometry -->
           <ng-container *ngFor="let complex of complexSearch.elements">
             <td>
-              <ng-container *ngIf="!!findInteractorInComplex(complex, interactor.interactor.identifier)">
-                <div class="verticalLineTop">.
-                </div>
-                <div class="stoichNum" title="{{ getStochiometry(complex, interactor.interactor.identifier) }}">
-                  {{ stochiometryOfInteractors(complex, interactor.interactor.identifier) }}
-                </div>
-                <div class="verticalLineBottom">.
-                </div>
-              </ng-container>
+              <div class="verticalLineTop"
+                   *ngIf="(stochiometryOfInteractors(complex, interactor.identifier)) != null">.
+              </div>
+              <div class="stoichNum" *ngIf="(stochiometryOfInteractors(complex, interactor.identifier))"
+                   title="{{ (getStochiometry(complex, interactor.identifier)) }}">
+                {{ (stochiometryOfInteractors(complex, interactor.identifier)) }}
+              </div>
+              <div class="verticalLineBottom"
+                   *ngIf="(stochiometryOfInteractors(complex, interactor.id)) != null">.
+              </div>
+              <div class="verticalLineTop"
+                   *ngIf="stoichiometryOfInteractorsMainTable(complex, interactor, complexSearch.elements)">.
+              </div>
               <ng-container class="stoichComponent"
-                            *ngIf="findInteractorsInSubComplex(complex, interactor.interactor.identifier).length > 0">
-                <div class="verticalLineTop">.
-                </div>
+                            *ngIf="stoichiometryOfInteractorsMainTable(complex, interactor, complexSearch.elements) ">
                 <!-- subcomplexes' interactors' stoichiometry -->
-                <div class="stoichNum" title="{{ getStoichiometrySubComplex(complex, interactor.interactor.identifier) }}">
-                  {{ stoichiometryOfInteractorsMainTable(complex, interactor.interactor.identifier) }}
-                </div>
-                <div class="verticalLineBottom">.
+                <div class="stoichNum"
+                     title="{{ (getStoichiometrySubComplex(complex, interactor, complexSearch.elements)) }}">
+                  {{ stoichiometryOfInteractorsMainTable(complex, interactor, complexSearch.elements) }}
                 </div>
               </ng-container>
+              <div class="verticalLineBottom"
+                   *ngIf="stoichiometryOfInteractorsMainTable(complex, interactor, complexSearch.elements)">.
+              </div>
             </td>
           </ng-container>
         </tr>
         <!-- Expandable menu for subcomplexes -->
-        <ng-container *ngIf="enrichedInteractors[i].expanded">
-          <ng-container *ngIf="!!enrichedInteractors[i].subComponents">
-            <tr *ngFor="let el of enrichedInteractors[i].subComponents">
-              <!-- Create an error when the components are not in the search results -->
-              <td style="background: #7e9394">
-                <div style="font-weight: bold">
-                  <a [routerLink]="['/complex/search']"
-                     [queryParams]="{query: el.identifier, page: 1}"
-                     target="_blank">
-                    {{ el.name }}
-                    <i class="{{interactorTypeIcon(el)}}" title="{{interactor.interactor.interactorType}}"></i>
-                    <i class="icon icon-functional small" data-icon="1"
-                       title="More complexes containing this interactor"></i>
-                  </a>
+        <ng-container *ngIf="buttonContainers[i]">
+          <tr *ngFor="let el of (componentToComplex(interactor, complexSearch.elements)).components">
+            <!-- Create an error when the components are not in the search results -->
+            <td style="background: #b7b8b8">
+              <div style="font-weight: bold">
+                <a [routerLink]="['/complex/search']"
+                   [queryParams]="{query: el.identifier, page: 1}"
+                   target="_blank">
+                  {{ el.interactorName }}
+                  <i class="{{interactorTypeIcon(el)}}" title="{{interactor.interactorType}}"></i>
+                  <i class="icon icon-functional small" data-icon="1"
+                     title="More complexes containing this interactor"></i>
+                </a>
+              </div>
+              <div *ngIf="showExternalLink(el)" class="interactorType">
+                <a href="{{el.identifierLink}}" target="_blank">{{ el.identifier }}
+                  <i class="icon icon-generic small" data-icon="x" title="More information"></i>
+                </a>
+              </div>
+            </td>
+            <ng-container *ngFor="let complex of complexSearch.elements">
+              <td style="background: #b7b8b8;">
+                <div class="verticalLineTop"
+                     *ngIf="stochiometryOfInteractors(complex, el.id) || stoichiometryOfInteractorsExpandable(complex, el)">
+                  .
                 </div>
-                <div *ngIf="showExternalLink(el)" class="interactorType">
-                  <a href="{{el.identifierLink}}" target="_blank">{{ el.identifier }}
-                    <i class="icon icon-generic small" data-icon="x" title="More information"></i>
-                  </a>
+                <div class="stoichNum"
+                     *ngIf="stochiometryOfInteractors(complex, el.identifier) || stoichiometryOfInteractorsExpandable(complex, el)"
+                     title="{{ (getStochiometry(complex, el.identifier)) }}">
+                  {{ stochiometryOfInteractors(complex, el.identifier) }}
+                  {{ stoichiometryOfInteractorsExpandable(complex, el) }}
+                </div>
+                <div class="verticalLineBottom"
+                     *ngIf="stochiometryOfInteractors(complex, el.id) || stoichiometryOfInteractorsExpandable(complex, el)">
+                  .
                 </div>
               </td>
-              <ng-container *ngFor="let complex of complexSearch.elements">
-                <td style="background: #7e9394;">
-                  <ng-container *ngIf="!!findInteractorInComplex(complex, el.identifier)">
-                    <div class="verticalLineTop">.
-                    </div>
-                    <div class="stoichNum"
-                         title="{{ getStochiometry(complex, el.identifier) }}">
-                      {{ stochiometryOfInteractors(complex, el.identifier) }}
-                    </div>
-                    <div class="verticalLineBottom">.
-                    </div>
-                  </ng-container>
-                  <ng-container
-                    *ngIf="!!findInteractorInExpandedSubComplex(enrichedInteractors[i], complex, el.identifier)">
-                    <!-- subcomplexes' interactors' stoichiometry -->
-                    <div class="verticalLineTop">.
-                    </div>
-                    <div class="stoichNum"
-                         title="{{ getStochiometryInExpandedSubComplex(enrichedInteractors[i], el.identifier) }}">
-                      {{ stoichiometryOfInteractorsExpandable(enrichedInteractors[i], el.identifier) }}
-                    </div>
-                    <div class="verticalLineBottom">.
-                    </div>
-                  </ng-container>
-                </td>
-              </ng-container>
-            </tr>
-          </ng-container>
+            </ng-container>
+          </tr>
         </ng-container>
       </ng-container>
     </ng-container>

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.html
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.html
@@ -3,7 +3,7 @@
     <!-- Interactors' column -->
     <ng-container *ngFor="let interactor of enrichedInteractors; let i=index">
       <ng-container>
-        <tr>
+        <tr *ngIf="!interactor.hidden">
           <td>
             <div style="font-weight: bold">
               {{ interactor.interactor.name }}

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.html
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.html
@@ -33,30 +33,28 @@
           <!-- Interactors' stoichiometry -->
           <ng-container *ngFor="let complex of complexSearch.elements">
             <td>
-              <div class="verticalLineTop"
-                   *ngIf="(stochiometryOfInteractors(complex, interactor.identifier)) != null">.
-              </div>
-              <div class="stoichNum" *ngIf="(stochiometryOfInteractors(complex, interactor.identifier))"
-                   title="{{ (getStochiometry(complex, interactor.identifier)) }}">
-                {{ (stochiometryOfInteractors(complex, interactor.identifier)) }}
-              </div>
-              <div class="verticalLineBottom"
-                   *ngIf="(stochiometryOfInteractors(complex, interactor.identifier)) != null">.
-              </div>
-              <div class="verticalLineTop"
-                   *ngIf="stoichiometryOfInteractorsMainTable(complex, interactor, complexSearch.elements)">.
-              </div>
-              <ng-container class="stoichComponent"
-                            *ngIf="stoichiometryOfInteractorsMainTable(complex, interactor, complexSearch.elements) ">
-                <!-- subcomplexes' interactors' stoichiometry -->
-                <div class="stoichNum"
-                     title="{{ (getStoichiometrySubComplex(complex, interactor, complexSearch.elements)) }}">
-                  {{ stoichiometryOfInteractorsMainTable(complex, interactor, complexSearch.elements) }}
+              <ng-container *ngIf="stochiometryOfInteractors(complex, interactor.identifier) != null">
+                <div class="verticalLineTop">.
+                </div>
+                <div class="stoichNum" title="{{ getStochiometry(complex, interactor.identifier) }}">
+                  {{ stochiometryOfInteractors(complex, interactor.identifier) }}
+                </div>
+                <div class="verticalLineBottom">.
                 </div>
               </ng-container>
-              <div class="verticalLineBottom"
-                   *ngIf="stoichiometryOfInteractorsMainTable(complex, interactor, complexSearch.elements)">.
-              </div>
+              <ng-container *ngIf="stoichiometryOfInteractorsMainTable(complex, interactor, complexSearch.elements)">
+                <div class="verticalLineTop">.
+                </div>
+                <ng-container class="stoichComponent">
+                  <!-- subcomplexes' interactors' stoichiometry -->
+                  <div class="stoichNum"
+                       title="{{ getStoichiometrySubComplex(complex, interactor, complexSearch.elements) }}">
+                    {{ stoichiometryOfInteractorsMainTable(complex, interactor, complexSearch.elements) }}
+                  </div>
+                </ng-container>
+                <div class="verticalLineBottom">.
+                </div>
+              </ng-container>
             </td>
           </ng-container>
         </tr>
@@ -83,20 +81,24 @@
             </td>
             <ng-container *ngFor="let complex of complexSearch.elements">
               <td style="background: #b7b8b8;">
-                <div class="verticalLineTop"
-                     *ngIf="stochiometryOfInteractors(complex, el.identifier) || stoichiometryOfInteractorsExpandable(complex, el)">
-                  .
-                </div>
-                <div class="stoichNum"
-                     *ngIf="stochiometryOfInteractors(complex, el.identifier) || stoichiometryOfInteractorsExpandable(complex, el)"
-                     title="{{ (getStochiometry(complex, el.identifier)) }}">
-                  {{ stochiometryOfInteractors(complex, el.identifier) }}
-                  {{ stoichiometryOfInteractorsExpandable(complex, el) }}
-                </div>
-                <div class="verticalLineBottom"
-                     *ngIf="stochiometryOfInteractors(complex, el.identifier) || stoichiometryOfInteractorsExpandable(complex, el)">
-                  .
-                </div>
+                <ng-container *ngIf="stochiometryOfInteractors(complex, el.identifier)">
+                  <div class="verticalLineTop">.
+                  </div>
+                  <div class="stoichNum" title="{{ (getStochiometry(complex, el.identifier)) }}">
+                    {{ stochiometryOfInteractors(complex, el.identifier) }}
+                  </div>
+                  <div class="verticalLineBottom">.
+                  </div>
+                </ng-container>
+                <ng-container *ngIf="stoichiometryOfInteractorsExpandable(complex, el)">
+                  <div class="verticalLineTop">.
+                  </div>
+                  <div class="stoichNum" title="{{ (getStochiometry(complex, el.identifier)) }}">
+                    {{ stoichiometryOfInteractorsExpandable(complex, el) }}
+                  </div>
+                  <div class="verticalLineBottom">.
+                  </div>
+                </ng-container>
               </td>
             </ng-container>
           </tr>

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.html
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.html
@@ -1,31 +1,31 @@
 <div class="Complex-navigator">
   <table class="interactors-table">
     <!-- Interactors' column -->
-    <ng-container *ngFor="let interactor of components; let i=index">
+    <ng-container *ngFor="let interactor of enrichedInteractors; let i=index">
       <ng-container>
-        <tr>
+        <tr *ngIf="!interactor.hidden">
           <td>
             <div style="font-weight: bold">
-              {{ interactor.name }}
-              <i class="{{interactorTypeIcon(interactor)}}" title="{{interactor.interactorType}}"></i>
+              {{ interactor.interactor.name }}
+              <i class="{{interactorTypeIcon(interactor.interactor)}}" title="{{interactor.interactor.interactorType}}"></i>
               <!-- Adding of the icons to access details of the interactor -->
               <a [routerLink]="['/complex/search']"
-                 [queryParams]="{query: interactor.identifier, page: 1}"
+                 [queryParams]="{query: interactor.interactor.identifier, page: 1}"
                  target="_blank">
                 <i class="icon icon-functional small" data-icon="1"
                    title="Complexes containing this interactor"></i>
               </a>
             </div>
             <!-- Icon for the expandable -->
-            <div class="container" *ngIf="isComponentASubcomplex(interactor);">
-              {{ interactor.identifier }}
-              <a title="{{ interactor.name }}'s interactors" (click)="toggleSubcomplexExpandable(i)">
+            <div class="container" *ngIf="interactor.isSubComplex">
+              {{ interactor.interactor.identifier }}
+              <a title="{{ interactor.interactor.name }}'s interactors" (click)="toggleSubcomplexExpandable(i)">
                 <i class="icon icon-common" data-icon="&#xf078;"
                    style="font-size:small; margin-top: 2px"></i>
               </a>
             </div>
-            <div *ngIf="showExternalLink(interactor)" class="interactorType">
-              <a href="{{interactor.identifierLink}}" target="_blank">{{ interactor.identifier }}
+            <div *ngIf="showExternalLink(interactor.interactor)" class="interactorType">
+              <a href="{{interactor.interactor.identifierLink}}" target="_blank">{{ interactor.interactor.identifier }}
                 <i class="icon icon-generic small" data-icon="x"></i>
               </a>
             </div>
@@ -33,73 +33,79 @@
           <!-- Interactors' stoichiometry -->
           <ng-container *ngFor="let complex of complexSearch.elements">
             <td>
-              <div class="verticalLineTop"
-                   *ngIf="(stochiometryOfInteractors(complex, interactor.identifier)) != null">.
-              </div>
-              <div class="stoichNum" *ngIf="(stochiometryOfInteractors(complex, interactor.identifier))"
-                   title="{{ (getStochiometry(complex, interactor.identifier)) }}">
-                {{ (stochiometryOfInteractors(complex, interactor.identifier)) }}
-              </div>
-              <div class="verticalLineBottom"
-                   *ngIf="(stochiometryOfInteractors(complex, interactor.id)) != null">.
-              </div>
-              <div class="verticalLineTop"
-                   *ngIf="stoichiometryOfInteractorsMainTable(complex, interactor, complexSearch.elements)">.
-              </div>
-              <ng-container class="stoichComponent"
-                            *ngIf="stoichiometryOfInteractorsMainTable(complex, interactor, complexSearch.elements) ">
-                <!-- subcomplexes' interactors' stoichiometry -->
-                <div class="stoichNum"
-                     title="{{ (getStoichiometrySubComplex(complex, interactor, complexSearch.elements)) }}">
-                  {{ stoichiometryOfInteractorsMainTable(complex, interactor, complexSearch.elements) }}
+              <ng-container *ngIf="!!findInteractorInComplex(complex, interactor.interactor.identifier)">
+                <div class="verticalLineTop">.
+                </div>
+                <div class="stoichNum" title="{{ getStochiometry(complex, interactor.interactor.identifier) }}">
+                  {{ stochiometryOfInteractors(complex, interactor.interactor.identifier) }}
+                </div>
+                <div class="verticalLineBottom">.
                 </div>
               </ng-container>
-              <div class="verticalLineBottom"
-                   *ngIf="stoichiometryOfInteractorsMainTable(complex, interactor, complexSearch.elements)">.
-              </div>
+              <ng-container class="stoichComponent"
+                            *ngIf="findInteractorsInSubComplex(complex, interactor.interactor.identifier).length > 0">
+                <div class="verticalLineTop">.
+                </div>
+                <!-- subcomplexes' interactors' stoichiometry -->
+                <div class="stoichNum" title="{{ getStoichiometrySubComplex(complex, interactor.interactor.identifier) }}">
+                  {{ stoichiometryOfInteractorsMainTable(complex, interactor.interactor.identifier) }}
+                </div>
+                <div class="verticalLineBottom">.
+                </div>
+              </ng-container>
             </td>
           </ng-container>
         </tr>
         <!-- Expandable menu for subcomplexes -->
-        <ng-container *ngIf="buttonContainers[i]">
-          <tr *ngFor="let el of (componentToComplex(interactor, complexSearch.elements)).components">
-            <!-- Create an error when the components are not in the search results -->
-            <td style="background: #b7b8b8">
-              <div style="font-weight: bold">
-                <a [routerLink]="['/complex/search']"
-                   [queryParams]="{query: el.identifier, page: 1}"
-                   target="_blank">
-                  {{ el.interactorName }}
-                  <i class="{{interactorTypeIcon(el)}}" title="{{interactor.interactorType}}"></i>
-                  <i class="icon icon-functional small" data-icon="1"
-                     title="More complexes containing this interactor"></i>
-                </a>
-              </div>
-              <div *ngIf="showExternalLink(el)" class="interactorType">
-                <a href="{{el.identifierLink}}" target="_blank">{{ el.identifier }}
-                  <i class="icon icon-generic small" data-icon="x" title="More information"></i>
-                </a>
-              </div>
-            </td>
-            <ng-container *ngFor="let complex of complexSearch.elements">
-              <td style="background: #b7b8b8;">
-                <div class="verticalLineTop"
-                     *ngIf="stochiometryOfInteractors(complex, el.id) || stoichiometryOfInteractorsExpandable(complex, el)">
-                  .
+        <ng-container *ngIf="enrichedInteractors[i].expanded">
+          <ng-container *ngIf="!!enrichedInteractors[i].subComponents">
+            <tr *ngFor="let el of enrichedInteractors[i].subComponents">
+              <!-- Create an error when the components are not in the search results -->
+              <td style="background: #7e9394">
+                <div style="font-weight: bold">
+                  <a [routerLink]="['/complex/search']"
+                     [queryParams]="{query: el.identifier, page: 1}"
+                     target="_blank">
+                    {{ el.name }}
+                    <i class="{{interactorTypeIcon(el)}}" title="{{interactor.interactor.interactorType}}"></i>
+                    <i class="icon icon-functional small" data-icon="1"
+                       title="More complexes containing this interactor"></i>
+                  </a>
                 </div>
-                <div class="stoichNum"
-                     *ngIf="stochiometryOfInteractors(complex, el.identifier) || stoichiometryOfInteractorsExpandable(complex, el)"
-                     title="{{ (getStochiometry(complex, el.identifier)) }}">
-                  {{ stochiometryOfInteractors(complex, el.identifier) }}
-                  {{ stoichiometryOfInteractorsExpandable(complex, el) }}
-                </div>
-                <div class="verticalLineBottom"
-                     *ngIf="stochiometryOfInteractors(complex, el.id) || stoichiometryOfInteractorsExpandable(complex, el)">
-                  .
+                <div *ngIf="showExternalLink(el)" class="interactorType">
+                  <a href="{{el.identifierLink}}" target="_blank">{{ el.identifier }}
+                    <i class="icon icon-generic small" data-icon="x" title="More information"></i>
+                  </a>
                 </div>
               </td>
-            </ng-container>
-          </tr>
+              <ng-container *ngFor="let complex of complexSearch.elements">
+                <td style="background: #7e9394;">
+                  <ng-container *ngIf="!!findInteractorInComplex(complex, el.identifier)">
+                    <div class="verticalLineTop">.
+                    </div>
+                    <div class="stoichNum"
+                         title="{{ getStochiometry(complex, el.identifier) }}">
+                      {{ stochiometryOfInteractors(complex, el.identifier) }}
+                    </div>
+                    <div class="verticalLineBottom">.
+                    </div>
+                  </ng-container>
+                  <ng-container
+                    *ngIf="!!findInteractorInExpandedSubComplex(enrichedInteractors[i], complex, el.identifier)">
+                    <!-- subcomplexes' interactors' stoichiometry -->
+                    <div class="verticalLineTop">.
+                    </div>
+                    <div class="stoichNum"
+                         title="{{ getStochiometryInExpandedSubComplex(enrichedInteractors[i], el.identifier) }}">
+                      {{ stoichiometryOfInteractorsExpandable(enrichedInteractors[i], el.identifier) }}
+                    </div>
+                    <div class="verticalLineBottom">.
+                    </div>
+                  </ng-container>
+                </td>
+              </ng-container>
+            </tr>
+          </ng-container>
         </ng-container>
       </ng-container>
     </ng-container>

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.html
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.html
@@ -1,31 +1,31 @@
 <div class="Complex-navigator">
   <table class="interactors-table">
     <!-- Interactors' column -->
-    <ng-container *ngFor="let interactor of interactors; let i=index">
+    <ng-container *ngFor="let interactor of enrichedInteractors; let i=index">
       <ng-container>
         <tr>
           <td>
             <div style="font-weight: bold">
-              {{ interactor.name }}
-              <i class="{{interactorTypeIcon(interactor)}}" title="{{interactor.interactorType}}"></i>
+              {{ interactor.interactor.name }}
+              <i class="{{interactorTypeIcon(interactor.interactor)}}" title="{{interactor.interactor.interactorType}}"></i>
               <!-- Adding of the icons to access details of the interactor -->
               <a [routerLink]="['/complex/search']"
-                 [queryParams]="{query: interactor.identifier, page: 1}"
+                 [queryParams]="{query: interactor.interactor.identifier, page: 1}"
                  target="_blank">
                 <i class="icon icon-functional small" data-icon="1"
                    title="Complexes containing this interactor"></i>
               </a>
             </div>
             <!-- Icon for the expandable -->
-            <div class="container" *ngIf="isComponentASubcomplex(interactor);">
-              {{ interactor.identifier }}
-              <a title="{{ interactor.name }}'s interactors" (click)="toggleSubcomplexExpandable(i)">
+            <div class="container" *ngIf="interactor.isSubComplex">
+              {{ interactor.interactor.identifier }}
+              <a title="{{ interactor.interactor.name }}'s interactors" (click)="toggleSubcomplexExpandable(i)">
                 <i class="icon icon-common" data-icon="&#xf078;"
                    style="font-size:small; margin-top: 2px"></i>
               </a>
             </div>
-            <div *ngIf="showExternalLink(interactor)" class="interactorType">
-              <a href="{{interactor.identifierLink}}" target="_blank">{{ interactor.identifier }}
+            <div *ngIf="showExternalLink(interactor.interactor)" class="interactorType">
+              <a href="{{interactor.interactor.identifierLink}}" target="_blank">{{ interactor.interactor.identifier }}
                 <i class="icon icon-generic small" data-icon="x"></i>
               </a>
             </div>
@@ -33,23 +33,23 @@
           <!-- Interactors' stoichiometry -->
           <ng-container *ngFor="let complex of complexSearch.elements">
             <td>
-              <ng-container *ngIf="stochiometryOfInteractors(complex, interactor.identifier) != null">
+              <ng-container *ngIf="stochiometryOfInteractors(complex, interactor.interactor.identifier) != null">
                 <div class="verticalLineTop">.
                 </div>
-                <div class="stoichNum" title="{{ getStochiometry(complex, interactor.identifier) }}">
-                  {{ stochiometryOfInteractors(complex, interactor.identifier) }}
+                <div class="stoichNum" title="{{ getStochiometry(complex, interactor.interactor.identifier) }}">
+                  {{ stochiometryOfInteractors(complex, interactor.interactor.identifier) }}
                 </div>
                 <div class="verticalLineBottom">.
                 </div>
               </ng-container>
-              <ng-container *ngIf="stoichiometryOfInteractorsMainTable(complex, interactor, complexSearch.elements)">
+              <ng-container *ngIf="stoichiometryOfInteractorsMainTable(complex, interactor.interactor, complexSearch.elements)">
                 <div class="verticalLineTop">.
                 </div>
                 <ng-container class="stoichComponent">
                   <!-- subcomplexes' interactors' stoichiometry -->
                   <div class="stoichNum"
-                       title="{{ getStoichiometrySubComplex(complex, interactor, complexSearch.elements) }}">
-                    {{ stoichiometryOfInteractorsMainTable(complex, interactor, complexSearch.elements) }}
+                       title="{{ getStoichiometrySubComplex(complex, interactor.interactor, complexSearch.elements) }}">
+                    {{ stoichiometryOfInteractorsMainTable(complex, interactor.interactor, complexSearch.elements) }}
                   </div>
                 </ng-container>
                 <div class="verticalLineBottom">.
@@ -59,8 +59,8 @@
           </ng-container>
         </tr>
         <!-- Expandable menu for subcomplexes -->
-        <ng-container *ngIf="buttonContainers[i]">
-          <tr *ngFor="let el of (componentToComplex(interactor, complexSearch.elements)).components">
+        <ng-container *ngIf="interactor.expanded">
+          <tr *ngFor="let el of (componentToComplex(interactor.interactor, complexSearch.elements)).components">
             <!-- Create an error when the components are not in the search results -->
             <td style="background: #b7b8b8">
               <div style="font-weight: bold">
@@ -68,7 +68,7 @@
                    [queryParams]="{query: el.identifier, page: 1}"
                    target="_blank">
                   {{ el.name }}
-                  <i class="{{interactorTypeIcon(el)}}" title="{{interactor.interactorType}}"></i>
+                  <i class="{{interactorTypeIcon(el)}}" title="{{interactor.interactor.interactorType}}"></i>
                   <i class="icon icon-functional small" data-icon="1"
                      title="More complexes containing this interactor"></i>
                 </a>

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.ts
@@ -8,6 +8,7 @@ import {of} from 'rxjs';
 
 class EnrichedInteractor {
   interactor: Interactor;
+  hidden: boolean;
   isSubComplex: boolean;
   expanded: boolean;
   subComponents: ComplexComponent[];
@@ -39,6 +40,7 @@ export class TableInteractorColumnComponent implements OnInit {
       const isSubComplex = interactor.interactorType === 'stable complex';
       const newEnrichedInteractor: EnrichedInteractor = {
         interactor,
+        hidden: false,
         isSubComplex,
         expanded: false,
         subComponents: null
@@ -144,7 +146,7 @@ export class TableInteractorColumnComponent implements OnInit {
     return null;
   }
 
-  public showExternalLink(component: Interactor | ComplexComponent): boolean {
+  showExternalLink(component: Interactor | ComplexComponent): boolean {
     return component.interactorType !== 'stable complex' && !!component.identifierLink;
   }
 
@@ -159,6 +161,26 @@ export class TableInteractorColumnComponent implements OnInit {
         if (i !== j) {
           this._enrichedInteractors[j].expanded = false;
         }
+      }
+
+      // 2. Hide any interactor now displayed in the expanded section
+      if (!!this._enrichedInteractors[i].subComponents) {
+        const subInteractorIds: string[] = this._enrichedInteractors[i].subComponents.map(component => component.identifier);
+        for (let j = 0; j < this._enrichedInteractors.length; j++) {
+          if (i !== j) {
+            if (subInteractorIds.includes(this._enrichedInteractors[j].interactor.identifier)) {
+              this._enrichedInteractors[j].hidden = true;
+            } else {
+              this._enrichedInteractors[j].hidden = false;
+            }
+          }
+        }
+      }
+    } else {
+      // EnrichedInteractor has been collapsed, we need to:
+      // 1. Display any interactor previously hidden
+      for (let j = 0; j < this._enrichedInteractors.length; j++) {
+        this._enrichedInteractors[j].hidden = false;
       }
     }
   }

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.ts
@@ -3,18 +3,6 @@ import {ComplexSearchResult} from '../../../../shared/model/complex-results/comp
 import {Interactor} from '../../../../shared/model/complex-results/interactor.model';
 import {Element} from '../../../../shared/model/complex-results/element.model';
 import {ComplexComponent} from '../../../../shared/model/complex-results/complex-component.model';
-import {Observable} from 'rxjs/Observable';
-import {of} from 'rxjs';
-import {ComplexPortalService} from '../../../../shared/service/complex-portal.service';
-import {map} from 'rxjs/operators';
-
-class EnrichedInteractor {
-  interactor: Interactor;
-  hidden: boolean;
-  isSubComplex: boolean;
-  expanded: boolean;
-  subComponents: ComplexComponent[];
-}
 
 @Component({
   selector: 'cp-table-interactor-column',
@@ -23,171 +11,141 @@ class EnrichedInteractor {
 })
 export class TableInteractorColumnComponent implements OnInit {
   @Input() complexSearch: ComplexSearchResult;
-  _enrichedInteractors: EnrichedInteractor[];
+  _components: Set<Interactor>;
 
-  constructor(private complexPortalService: ComplexPortalService) {
+  buttonContainers = [];
+
+  constructor() {
   }
 
   ngOnInit() {
   }
 
-  get enrichedInteractors(): EnrichedInteractor[] {
-    return this._enrichedInteractors;
+  get components(): Set<Interactor> {
+    return this._components;
   }
 
   @Input()
-  set interactors(interactors: Set<Interactor>) {
-    this._enrichedInteractors = [];
-    for (const interactor of interactors) {
-      const isSubComplex = interactor.interactorType === 'stable complex';
-      const newEnrichedInteractor: EnrichedInteractor = {
-        interactor,
-        hidden: false,
-        isSubComplex,
-        expanded: false,
-        subComponents: null
-      };
-      if (isSubComplex) {
-        this.loadSubInteractors(newEnrichedInteractor).subscribe(subComponents => newEnrichedInteractor.subComponents = subComponents);
-      }
-      this._enrichedInteractors.push(newEnrichedInteractor);
+  set components(value: Set<Interactor>) {
+    this.buttonContainers = [];
+    this._components = value;
+    for (let i = 0; i < this._components.size; i++) {
+      this.buttonContainers.push(false);
     }
   }
 
-  findInteractorInComplex(complex: Element, componentId: string): ComplexComponent {
-    return complex.components.find(component => component.identifier === componentId);
-  }
-
-  findInteractorsInSubComplex(complex: Element, interactorId: string): ComplexComponent[] {
-    return this._enrichedInteractors
-      // filter subcomplexes
-      .filter(interactor => interactor.isSubComplex)
-      // filter subcomplexes included in complex
-      .filter(interactor =>
-        complex.components.some(component => component.identifier === interactor.interactor.identifier))
-      // filter subcomplexes that match the componentId
-      .filter(interactor => !!interactor.subComponents)
-      .map(interactor => interactor.subComponents.find(subComponent => subComponent.identifier === interactorId))
-      .filter(component => !!component);
-  }
-
-  public findInteractorInExpandedSubComplex(interactor: EnrichedInteractor, complex: Element, interactorId: string): ComplexComponent {
-    if (complex.components.some(component => component.identifier === interactor.interactor.identifier)) {
-      return interactor.subComponents.find(component => component.identifier === interactorId);
-    }
-    return null;
-  }
-
-  stochiometryOfInteractors(complex: Element, interactorId: string): string {
-    const match = this.findInteractorInComplex(complex, interactorId);
-    if (!!match) {
-      return this.formatStochiometryValues(match.stochiometry);
-    }
-    return null;
-  }
-
-  stoichiometryOfInteractorsExpandable(interactor: EnrichedInteractor, interactorId: string): string {
-    const match = this.findInteractorInSubcomplex(interactor, interactorId);
-    if (!!match) {
-      return this.formatStochiometryValues(match.stochiometry);
-    }
-    return null;
-  }
-
-  stoichiometryOfInteractorsMainTable(complex: Element, interactorId: string): string {
-    const matches = this.findInteractorsInSubComplex(complex, interactorId);
-    if (matches.length > 0) {
-      const stochiometryValues = this.addedStoichiometryValues(matches);
-      if (!!stochiometryValues) {
-        if (stochiometryValues[0] === stochiometryValues[1]) {
-          return stochiometryValues[0].toString();
-        } else {
-          return `${stochiometryValues[0]}, ${stochiometryValues[1]}`;
-        }
-      } else {
-        return ' ';
-      }
-    }
-    return null;
-  }
-
-  getStochiometry(complex: Element, componentId: string): string {
-    const match = this.findInteractorInComplex(complex, componentId);
+  public stochiometryOfInteractors(complex: Element, componentId: string): string {
+    const match = complex.components.find(component => component.identifier === componentId);
     if (!!match) {
       if (!!match.stochiometry) {
-        return 'Stoichiometry values: ' + (match.stochiometry);
+        // selection of the maxvalue
+        return (match.stochiometry).replace('minValue: ', '').replace('maxValue: ', ''); // .substring to only select the maxValue
       } else {
-        return 'No stoichiometry data available'; // sometimes we don't have the stoichiometry value
+        return ' '; // sometimes we don't have the stoichiometry value
       }
     }
     return null;
   }
 
-  getStoichiometrySubComplex(complex: Element, interactorId: string): string {
-    const matches = this.findInteractorsInSubComplex(complex, interactorId);
-    if (matches.length > 0) {
-      const stochiometryValues = this.addedStoichiometryValues(matches);
-      if (!!stochiometryValues) {
-        return `Stoichiometry values: minValue: ${stochiometryValues[0]}, maxValue: ${stochiometryValues[1]}`;
+  public stoichiometryOfInteractorsExpandable(complex: Element, interactor: ComplexComponent): string {
+    /* Retrieve the stoichiometry of the interactors of subcomplexes to display them in the main complex */
+    const matchSub = complex.components.find(component => component.interactorType === 'stable complex'); /* look for subcomplexes */
+    if (!!matchSub) {
+      if (!!interactor.stochiometry) {
+        // selection of the range
+        return (interactor.stochiometry).replace('minValue: ', '').replace('maxValue: ', '');
       } else {
-        return 'No stoichiometry data available'; // sometimes we don't have the stoichiometry value
+        return ' '; // sometimes we don't have the stoichiometry value
       }
     }
     return null;
   }
 
-  getStochiometryInExpandedSubComplex(interactor: EnrichedInteractor, interactorId: string): string {
-    const match = this.findInteractorInSubcomplex(interactor, interactorId);
-    if (!!match) {
-      if (!!match.stochiometry) {
-        return 'Stoichiometry values: ' + (match.stochiometry);
-      } else {
-        return 'No stoichiometry data available'; // sometimes we don't have the stoichiometry value
-      }
-    }
-    return null;
-  }
-
-  showExternalLink(component: Interactor | ComplexComponent): boolean {
-    return component.interactorType !== 'stable complex' && !!component.identifierLink;
-  }
-
-  toggleSubcomplexExpandable(i: number): void {
-    this._enrichedInteractors[i].expanded = !this._enrichedInteractors[i].expanded;
-
-    if (this._enrichedInteractors[i].expanded) {
-      // EnrichedInteractor has been expanded, we need to:
-
-      // 1. Collapse the other ones, in case there is any other expanded
-      for (let j = 0; j < this._enrichedInteractors.length; j++) {
-        if (i !== j) {
-          this._enrichedInteractors[j].expanded = false;
-        }
-      }
-
-      // 2. Hide any interactor now displayed in the expanded section
-      if (!!this._enrichedInteractors[i].subComponents) {
-        const subInteractorIds: string[] = this._enrichedInteractors[i].subComponents.map(component => component.identifier);
-        for (let j = 0; j < this._enrichedInteractors.length; j++) {
-          if (i !== j) {
-            if (subInteractorIds.includes(this._enrichedInteractors[j].interactor.identifier)) {
-              this._enrichedInteractors[j].hidden = true;
+  public stoichiometryOfInteractorsMainTable(complex: Element, interactor: Interactor, complexSearch: Element[]): string {
+    // Add the stoichiometry number of subcomplexes' interactors into the main complex containing them
+    const subcomplexesArray = complex.components.filter(component => (component.interactorType === 'stable complex'));
+    if (!!subcomplexesArray) {
+      for (const subcomplex of subcomplexesArray) {
+        const subComplexToComplex = this.componentToComplex(subcomplex, complexSearch);
+        // convert the elements of the subcomplexes' array into compplexes
+        for (const el of subComplexToComplex.components) {
+          if (el.identifier === interactor.identifier) {
+            if (!!el.stochiometry) {
+              // selection of the range
+              return (el.stochiometry).replace('minValue: ', '').replace('maxValue: ', '');
             } else {
-              this._enrichedInteractors[j].hidden = false;
+              return ' '; // sometimes we don't have the stoichiometry value
             }
           }
         }
       }
-    } else {
-      // EnrichedInteractor has been collapsed, we need to:
-      // 1. Display any interactor previously hidden
-      for (let j = 0; j < this._enrichedInteractors.length; j++) {
-        this._enrichedInteractors[j].hidden = false;
-      }
     }
+    return null;
   }
 
-  interactorTypeIcon(component: Interactor): string {
+  public getStochiometry(complex: Element, componentId: string): string {
+    // used when hovering on the stoichiometry circle
+    const match = complex.components.find(component => component.identifier === componentId);
+    if (!!match) {
+      if (!!match.stochiometry) {
+        return 'Stoichiometry values: ' + (match.stochiometry);
+      } else {
+        return 'No stoichiometry data available'; // sometimes we don't have the stoichiometry value
+      }
+    }
+    return null;
+  }
+
+  public getStoichiometrySubComplex(complex: Element, interactor: Interactor, complexSearch: Element[]): string {
+    const subcomplexesArray = complex.components.filter(component => (component.interactorType === 'stable complex'));
+    if (!!subcomplexesArray) {
+      for (const subcomplex of subcomplexesArray) {
+        const subComplexToComplex = this.componentToComplex(subcomplex, complexSearch);
+        // convert the elements of the subcomplexes' array into complexes
+        for (const el of subComplexToComplex.components) {
+          if (el.identifier === interactor.identifier) {
+            if (!!el.stochiometry) {
+              return el.stochiometry;
+            } else {
+              return 'No stoichiometry data available'; // sometimes we don't have the stoichiometry value
+            }
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  public isComponentASubcomplex(component: Interactor): boolean {
+    return (component.interactorType) === 'stable complex';
+  }
+
+  public componentToComplex(component: Interactor | ComplexComponent, ComplexSearch: Element[]): Element {
+    // this function convert a interactor (subcomplexes) into a complex in order to retrieve its components
+    return ComplexSearch.find(complex => complex.complexAC === component.identifier);
+  }
+
+  public findConnections(complex): boolean {
+    // test to display the line // may be fixed after access to database
+    const componentsArray = Array.from(this.components);
+    let connection: boolean;
+    for (let i = 0; i < complex.components.length - 1; i++) {
+      for (let j = 0; j < componentsArray.length - 1; j++) {
+        connection = (complex.components[i].id === componentsArray[j].id) && (complex.components[i + 1].id === componentsArray[j + 1].id);
+      }
+    }
+    return connection;
+  }
+
+  public showExternalLink(component: Interactor | ComplexComponent): boolean {
+    return component.interactorType !== 'stable complex' && !!component.identifierLink;
+  }
+
+  toggleSubcomplexExpandable(i: number): void {
+    this.buttonContainers[i] = !this.buttonContainers[i];
+  }
+
+  public interactorTypeIcon(component: Interactor): string {
     if (component.interactorType === 'protein') {
       return 'icon icon-conceptual icon-proteins';
     } else if (component.interactorType === 'ribonucleic acid') {
@@ -198,76 +156,5 @@ export class TableInteractorColumnComponent implements OnInit {
       return 'icon icon-conceptual icon-systems';
     }
     return '';
-  }
-
-  private loadSubInteractors(interactor: EnrichedInteractor): Observable<ComplexComponent[]> {
-    // this function returns the list of subcomponents of an interactor of type stable complex
-    const foundComplex: Element = this.complexSearch.elements.find(complex => complex.complexAC === interactor.interactor.identifier);
-    if (!!foundComplex) {
-      return of(foundComplex.components);
-    } else {
-      // Actually call the back-end to fetch these
-      return this.complexPortalService.getComplexAc(interactor.interactor.identifier)
-        .pipe(map(complex => complex.participants.map(participant => new ComplexComponent(
-          participant.identifier,
-          participant.identifierLink,
-          participant.name,
-          participant.description,
-          participant.stochiometry,
-          participant.interactorType))));
-    }
-  }
-
-  private findInteractorInSubcomplex(interactor: EnrichedInteractor, interactorId: string): ComplexComponent {
-    return interactor.subComponents.find(component => component.identifier === interactorId);
-  }
-
-  private fetchValuesFromStochiometry(stochiometry: string) {
-    const pattern = 'minValue: ([0-9+]), maxValue: ([0-9+])';
-    return stochiometry.match(pattern);
-  }
-
-  private formatStochiometryValues(stochiometry: string): string {
-    if (!!stochiometry) {
-      const matchedStochometry = this.fetchValuesFromStochiometry(stochiometry);
-      if (!!matchedStochometry) {
-        // tslint:disable-next-line:radix
-        const minValue = parseInt(matchedStochometry[1]);
-        // tslint:disable-next-line:radix
-        const maxValue = parseInt(matchedStochometry[2]);
-        if (minValue === maxValue) {
-          return minValue.toString();
-        } else {
-          return `${minValue}, ${maxValue}`;
-        }
-      }
-    }
-    return ' '; // sometimes we don't have the stoichiometry value
-  }
-
-  private addedStoichiometryValues(components: ComplexComponent[]): [number, number] {
-    let minValue: number = null;
-    let maxValue: number = null;
-    for (const component of components) {
-      if (!!component.stochiometry) {
-        const matchedStochometry = this.fetchValuesFromStochiometry(component.stochiometry);
-        if (!!matchedStochometry) {
-          if (minValue === null) {
-            minValue = 0;
-          }
-          if (maxValue === null) {
-            maxValue = 0;
-          }
-          // tslint:disable-next-line:radix
-          minValue += parseInt(matchedStochometry[1]);
-          // tslint:disable-next-line:radix
-          maxValue += parseInt(matchedStochometry[2]);
-        }
-      }
-    }
-    if (minValue !== null && maxValue !== null) {
-      return [minValue, maxValue];
-    }
-    return null;
   }
 }

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.ts
@@ -11,7 +11,7 @@ import {ComplexComponent} from '../../../../shared/model/complex-results/complex
 })
 export class TableInteractorColumnComponent implements OnInit {
   @Input() complexSearch: ComplexSearchResult;
-  _components: Set<Interactor>;
+  _interactors: Set<Interactor>;
 
   buttonContainers = [];
 
@@ -21,21 +21,21 @@ export class TableInteractorColumnComponent implements OnInit {
   ngOnInit() {
   }
 
-  get components(): Set<Interactor> {
-    return this._components;
+  get interactors(): Set<Interactor> {
+    return this._interactors;
   }
 
   @Input()
-  set components(value: Set<Interactor>) {
+  set interactors(value: Set<Interactor>) {
     this.buttonContainers = [];
-    this._components = value;
-    for (let i = 0; i < this._components.size; i++) {
+    this._interactors = value;
+    for (let i = 0; i < this._interactors.size; i++) {
       this.buttonContainers.push(false);
     }
   }
 
-  public stochiometryOfInteractors(complex: Element, componentId: string): string {
-    const match = complex.components.find(component => component.identifier === componentId);
+  public stochiometryOfInteractors(complex: Element, interactorId: string): string {
+    const match = complex.components.find(component => component.identifier === interactorId);
     if (!!match) {
       if (!!match.stochiometry) {
         // selection of the maxvalue
@@ -47,13 +47,13 @@ export class TableInteractorColumnComponent implements OnInit {
     return null;
   }
 
-  public stoichiometryOfInteractorsExpandable(complex: Element, interactor: ComplexComponent): string {
+  public stoichiometryOfInteractorsExpandable(complex: Element, component: ComplexComponent): string {
     /* Retrieve the stoichiometry of the interactors of subcomplexes to display them in the main complex */
     const matchSub = complex.components.find(component => component.interactorType === 'stable complex'); /* look for subcomplexes */
     if (!!matchSub) {
-      if (!!interactor.stochiometry) {
+      if (!!component.stochiometry) {
         // selection of the range
-        return (interactor.stochiometry).replace('minValue: ', '').replace('maxValue: ', '');
+        return (component.stochiometry).replace('minValue: ', '').replace('maxValue: ', '');
       } else {
         return ' '; // sometimes we don't have the stoichiometry value
       }
@@ -83,9 +83,9 @@ export class TableInteractorColumnComponent implements OnInit {
     return null;
   }
 
-  public getStochiometry(complex: Element, componentId: string): string {
+  public getStochiometry(complex: Element, interactorId: string): string {
     // used when hovering on the stoichiometry circle
-    const match = complex.components.find(component => component.identifier === componentId);
+    const match = complex.components.find(component => component.identifier === interactorId);
     if (!!match) {
       if (!!match.stochiometry) {
         return 'Stoichiometry values: ' + (match.stochiometry);
@@ -116,25 +116,13 @@ export class TableInteractorColumnComponent implements OnInit {
     return null;
   }
 
-  public isComponentASubcomplex(component: Interactor): boolean {
-    return (component.interactorType) === 'stable complex';
+  public isComponentASubcomplex(interactor: Interactor): boolean {
+    return (interactor.interactorType) === 'stable complex';
   }
 
   public componentToComplex(component: Interactor | ComplexComponent, ComplexSearch: Element[]): Element {
     // this function convert a interactor (subcomplexes) into a complex in order to retrieve its components
     return ComplexSearch.find(complex => complex.complexAC === component.identifier);
-  }
-
-  public findConnections(complex): boolean {
-    // test to display the line // may be fixed after access to database
-    const componentsArray = Array.from(this.components);
-    let connection: boolean;
-    for (let i = 0; i < complex.components.length - 1; i++) {
-      for (let j = 0; j < componentsArray.length - 1; j++) {
-        connection = (complex.components[i].id === componentsArray[j].id) && (complex.components[i + 1].id === componentsArray[j + 1].id);
-      }
-    }
-    return connection;
   }
 
   public showExternalLink(component: Interactor | ComplexComponent): boolean {
@@ -145,14 +133,14 @@ export class TableInteractorColumnComponent implements OnInit {
     this.buttonContainers[i] = !this.buttonContainers[i];
   }
 
-  public interactorTypeIcon(component: Interactor): string {
-    if (component.interactorType === 'protein') {
+  public interactorTypeIcon(interactor: Interactor): string {
+    if (interactor.interactorType === 'protein') {
       return 'icon icon-conceptual icon-proteins';
-    } else if (component.interactorType === 'ribonucleic acid') {
+    } else if (interactor.interactorType === 'ribonucleic acid') {
       return 'icon icon-conceptual icon-dna';
-    } else if (component.interactorType === 'small molecule') {
+    } else if (interactor.interactorType === 'small molecule') {
       return 'icon icon-conceptual icon-chemical';
-    } else if (component.interactorType === 'stable complex') {
+    } else if (interactor.interactorType === 'stable complex') {
       return 'icon icon-conceptual icon-systems';
     }
     return '';

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.ts
@@ -3,6 +3,18 @@ import {ComplexSearchResult} from '../../../../shared/model/complex-results/comp
 import {Interactor} from '../../../../shared/model/complex-results/interactor.model';
 import {Element} from '../../../../shared/model/complex-results/element.model';
 import {ComplexComponent} from '../../../../shared/model/complex-results/complex-component.model';
+import {Observable} from 'rxjs/Observable';
+import {of} from 'rxjs';
+import {ComplexPortalService} from '../../../../shared/service/complex-portal.service';
+import {map} from 'rxjs/operators';
+
+class EnrichedInteractor {
+  interactor: Interactor;
+  hidden: boolean;
+  isSubComplex: boolean;
+  expanded: boolean;
+  subComponents: ComplexComponent[];
+}
 
 @Component({
   selector: 'cp-table-interactor-column',
@@ -11,81 +23,96 @@ import {ComplexComponent} from '../../../../shared/model/complex-results/complex
 })
 export class TableInteractorColumnComponent implements OnInit {
   @Input() complexSearch: ComplexSearchResult;
-  _components: Set<Interactor>;
+  _enrichedInteractors: EnrichedInteractor[];
 
-  buttonContainers = [];
-
-  constructor() {
+  constructor(private complexPortalService: ComplexPortalService) {
   }
 
   ngOnInit() {
   }
 
-  get components(): Set<Interactor> {
-    return this._components;
+  get enrichedInteractors(): EnrichedInteractor[] {
+    return this._enrichedInteractors;
   }
 
   @Input()
-  set components(value: Set<Interactor>) {
-    this.buttonContainers = [];
-    this._components = value;
-    for (let i = 0; i < this._components.size; i++) {
-      this.buttonContainers.push(false);
+  set interactors(interactors: Set<Interactor>) {
+    this._enrichedInteractors = [];
+    for (const interactor of interactors) {
+      const isSubComplex = interactor.interactorType === 'stable complex';
+      const newEnrichedInteractor: EnrichedInteractor = {
+        interactor,
+        hidden: false,
+        isSubComplex,
+        expanded: false,
+        subComponents: null
+      };
+      if (isSubComplex) {
+        this.loadSubInteractors(newEnrichedInteractor).subscribe(subComponents => newEnrichedInteractor.subComponents = subComponents);
+      }
+      this._enrichedInteractors.push(newEnrichedInteractor);
     }
   }
 
-  public stochiometryOfInteractors(complex: Element, componentId: string): string {
-    const match = complex.components.find(component => component.identifier === componentId);
+  findInteractorInComplex(complex: Element, componentId: string): ComplexComponent {
+    return complex.components.find(component => component.identifier === componentId);
+  }
+
+  findInteractorsInSubComplex(complex: Element, interactorId: string): ComplexComponent[] {
+    return this._enrichedInteractors
+      // filter subcomplexes
+      .filter(interactor => interactor.isSubComplex)
+      // filter subcomplexes included in complex
+      .filter(interactor =>
+        complex.components.some(component => component.identifier === interactor.interactor.identifier))
+      // filter subcomplexes that match the componentId
+      .filter(interactor => !!interactor.subComponents)
+      .map(interactor => interactor.subComponents.find(subComponent => subComponent.identifier === interactorId))
+      .filter(component => !!component);
+  }
+
+  public findInteractorInExpandedSubComplex(interactor: EnrichedInteractor, complex: Element, interactorId: string): ComplexComponent {
+    if (complex.components.some(component => component.identifier === interactor.interactor.identifier)) {
+      return interactor.subComponents.find(component => component.identifier === interactorId);
+    }
+    return null;
+  }
+
+  stochiometryOfInteractors(complex: Element, interactorId: string): string {
+    const match = this.findInteractorInComplex(complex, interactorId);
     if (!!match) {
-      if (!!match.stochiometry) {
-        // selection of the maxvalue
-        return (match.stochiometry).replace('minValue: ', '').replace('maxValue: ', ''); // .substring to only select the maxValue
-      } else {
-        return ' '; // sometimes we don't have the stoichiometry value
-      }
+      return this.formatStochiometryValues(match.stochiometry);
     }
     return null;
   }
 
-  public stoichiometryOfInteractorsExpandable(complex: Element, interactor: ComplexComponent): string {
-    /* Retrieve the stoichiometry of the interactors of subcomplexes to display them in the main complex */
-    const matchSub = complex.components.find(component => component.interactorType === 'stable complex'); /* look for subcomplexes */
-    if (!!matchSub) {
-      if (!!interactor.stochiometry) {
-        // selection of the range
-        return (interactor.stochiometry).replace('minValue: ', '').replace('maxValue: ', '');
-      } else {
-        return ' '; // sometimes we don't have the stoichiometry value
-      }
+  stoichiometryOfInteractorsExpandable(interactor: EnrichedInteractor, interactorId: string): string {
+    const match = this.findInteractorInSubcomplex(interactor, interactorId);
+    if (!!match) {
+      return this.formatStochiometryValues(match.stochiometry);
     }
     return null;
   }
 
-  public stoichiometryOfInteractorsMainTable(complex: Element, interactor: Interactor, complexSearch: Element[]): string {
-    // Add the stoichiometry number of subcomplexes' interactors into the main complex containing them
-    const subcomplexesArray = complex.components.filter(component => (component.interactorType === 'stable complex'));
-    if (!!subcomplexesArray) {
-      for (const subcomplex of subcomplexesArray) {
-        const subComplexToComplex = this.componentToComplex(subcomplex, complexSearch);
-        // convert the elements of the subcomplexes' array into compplexes
-        for (const el of subComplexToComplex.components) {
-          if (el.identifier === interactor.identifier) {
-            if (!!el.stochiometry) {
-              // selection of the range
-              return (el.stochiometry).replace('minValue: ', '').replace('maxValue: ', '');
-            } else {
-              return ' '; // sometimes we don't have the stoichiometry value
-            }
-          }
+  stoichiometryOfInteractorsMainTable(complex: Element, interactorId: string): string {
+    const matches = this.findInteractorsInSubComplex(complex, interactorId);
+    if (matches.length > 0) {
+      const stochiometryValues = this.addedStoichiometryValues(matches);
+      if (!!stochiometryValues) {
+        if (stochiometryValues[0] === stochiometryValues[1]) {
+          return stochiometryValues[0].toString();
+        } else {
+          return `${stochiometryValues[0]}, ${stochiometryValues[1]}`;
         }
+      } else {
+        return ' ';
       }
     }
     return null;
   }
 
-  public getStochiometry(complex: Element, componentId: string): string {
-    // used when hovering on the stoichiometry circle
-    const match = complex.components.find(component => component.identifier === componentId);
+  getStochiometry(complex: Element, componentId: string): string {
+    const match = this.findInteractorInComplex(complex, componentId);
     if (!!match) {
       if (!!match.stochiometry) {
         return 'Stoichiometry values: ' + (match.stochiometry);
@@ -96,56 +123,71 @@ export class TableInteractorColumnComponent implements OnInit {
     return null;
   }
 
-  public getStoichiometrySubComplex(complex: Element, interactor: Interactor, complexSearch: Element[]): string {
-    const subcomplexesArray = complex.components.filter(component => (component.interactorType === 'stable complex'));
-    if (!!subcomplexesArray) {
-      for (const subcomplex of subcomplexesArray) {
-        const subComplexToComplex = this.componentToComplex(subcomplex, complexSearch);
-        // convert the elements of the subcomplexes' array into complexes
-        for (const el of subComplexToComplex.components) {
-          if (el.identifier === interactor.identifier) {
-            if (!!el.stochiometry) {
-              return el.stochiometry;
-            } else {
-              return 'No stoichiometry data available'; // sometimes we don't have the stoichiometry value
-            }
-          }
-        }
+  getStoichiometrySubComplex(complex: Element, interactorId: string): string {
+    const matches = this.findInteractorsInSubComplex(complex, interactorId);
+    if (matches.length > 0) {
+      const stochiometryValues = this.addedStoichiometryValues(matches);
+      if (!!stochiometryValues) {
+        return `Stoichiometry values: minValue: ${stochiometryValues[0]}, maxValue: ${stochiometryValues[1]}`;
+      } else {
+        return 'No stoichiometry data available'; // sometimes we don't have the stoichiometry value
       }
     }
     return null;
   }
 
-  public isComponentASubcomplex(component: Interactor): boolean {
-    return (component.interactorType) === 'stable complex';
-  }
-
-  public componentToComplex(component: Interactor | ComplexComponent, ComplexSearch: Element[]): Element {
-    // this function convert a interactor (subcomplexes) into a complex in order to retrieve its components
-    return ComplexSearch.find(complex => complex.complexAC === component.identifier);
-  }
-
-  public findConnections(complex): boolean {
-    // test to display the line // may be fixed after access to database
-    const componentsArray = Array.from(this.components);
-    let connection: boolean;
-    for (let i = 0; i < complex.components.length - 1; i++) {
-      for (let j = 0; j < componentsArray.length - 1; j++) {
-        connection = (complex.components[i].id === componentsArray[j].id) && (complex.components[i + 1].id === componentsArray[j + 1].id);
+  getStochiometryInExpandedSubComplex(interactor: EnrichedInteractor, interactorId: string): string {
+    const match = this.findInteractorInSubcomplex(interactor, interactorId);
+    if (!!match) {
+      if (!!match.stochiometry) {
+        return 'Stoichiometry values: ' + (match.stochiometry);
+      } else {
+        return 'No stoichiometry data available'; // sometimes we don't have the stoichiometry value
       }
     }
-    return connection;
+    return null;
   }
 
-  public showExternalLink(component: Interactor | ComplexComponent): boolean {
+  showExternalLink(component: Interactor | ComplexComponent): boolean {
     return component.interactorType !== 'stable complex' && !!component.identifierLink;
   }
 
   toggleSubcomplexExpandable(i: number): void {
-    this.buttonContainers[i] = !this.buttonContainers[i];
+    this._enrichedInteractors[i].expanded = !this._enrichedInteractors[i].expanded;
+
+    if (this._enrichedInteractors[i].expanded) {
+      // EnrichedInteractor has been expanded, we need to:
+
+      // 1. Collapse the other ones, in case there is any other expanded
+      for (let j = 0; j < this._enrichedInteractors.length; j++) {
+        if (i !== j) {
+          this._enrichedInteractors[j].expanded = false;
+        }
+      }
+
+      // 2. Hide any interactor now displayed in the expanded section
+      if (!!this._enrichedInteractors[i].subComponents) {
+        const subInteractorIds: string[] = this._enrichedInteractors[i].subComponents.map(component => component.identifier);
+        for (let j = 0; j < this._enrichedInteractors.length; j++) {
+          if (i !== j) {
+            if (subInteractorIds.includes(this._enrichedInteractors[j].interactor.identifier)) {
+              this._enrichedInteractors[j].hidden = true;
+            } else {
+              this._enrichedInteractors[j].hidden = false;
+            }
+          }
+        }
+      }
+    } else {
+      // EnrichedInteractor has been collapsed, we need to:
+      // 1. Display any interactor previously hidden
+      for (let j = 0; j < this._enrichedInteractors.length; j++) {
+        this._enrichedInteractors[j].hidden = false;
+      }
+    }
   }
 
-  public interactorTypeIcon(component: Interactor): string {
+  interactorTypeIcon(component: Interactor): string {
     if (component.interactorType === 'protein') {
       return 'icon icon-conceptual icon-proteins';
     } else if (component.interactorType === 'ribonucleic acid') {
@@ -156,5 +198,76 @@ export class TableInteractorColumnComponent implements OnInit {
       return 'icon icon-conceptual icon-systems';
     }
     return '';
+  }
+
+  private loadSubInteractors(interactor: EnrichedInteractor): Observable<ComplexComponent[]> {
+    // this function returns the list of subcomponents of an interactor of type stable complex
+    const foundComplex: Element = this.complexSearch.elements.find(complex => complex.complexAC === interactor.interactor.identifier);
+    if (!!foundComplex) {
+      return of(foundComplex.components);
+    } else {
+      // Actually call the back-end to fetch these
+      return this.complexPortalService.getComplexAc(interactor.interactor.identifier)
+        .pipe(map(complex => complex.participants.map(participant => new ComplexComponent(
+          participant.identifier,
+          participant.identifierLink,
+          participant.name,
+          participant.description,
+          participant.stochiometry,
+          participant.interactorType))));
+    }
+  }
+
+  private findInteractorInSubcomplex(interactor: EnrichedInteractor, interactorId: string): ComplexComponent {
+    return interactor.subComponents.find(component => component.identifier === interactorId);
+  }
+
+  private fetchValuesFromStochiometry(stochiometry: string) {
+    const pattern = 'minValue: ([0-9+]), maxValue: ([0-9+])';
+    return stochiometry.match(pattern);
+  }
+
+  private formatStochiometryValues(stochiometry: string): string {
+    if (!!stochiometry) {
+      const matchedStochometry = this.fetchValuesFromStochiometry(stochiometry);
+      if (!!matchedStochometry) {
+        // tslint:disable-next-line:radix
+        const minValue = parseInt(matchedStochometry[1]);
+        // tslint:disable-next-line:radix
+        const maxValue = parseInt(matchedStochometry[2]);
+        if (minValue === maxValue) {
+          return minValue.toString();
+        } else {
+          return `${minValue}, ${maxValue}`;
+        }
+      }
+    }
+    return ' '; // sometimes we don't have the stoichiometry value
+  }
+
+  private addedStoichiometryValues(components: ComplexComponent[]): [number, number] {
+    let minValue: number = null;
+    let maxValue: number = null;
+    for (const component of components) {
+      if (!!component.stochiometry) {
+        const matchedStochometry = this.fetchValuesFromStochiometry(component.stochiometry);
+        if (!!matchedStochometry) {
+          if (minValue === null) {
+            minValue = 0;
+          }
+          if (maxValue === null) {
+            maxValue = 0;
+          }
+          // tslint:disable-next-line:radix
+          minValue += parseInt(matchedStochometry[1]);
+          // tslint:disable-next-line:radix
+          maxValue += parseInt(matchedStochometry[2]);
+        }
+      }
+    }
+    if (minValue !== null && maxValue !== null) {
+      return [minValue, maxValue];
+    }
+    return null;
   }
 }

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.ts
@@ -5,6 +5,8 @@ import {Element} from '../../../../shared/model/complex-results/element.model';
 import {ComplexComponent} from '../../../../shared/model/complex-results/complex-component.model';
 import {Observable} from 'rxjs/Observable';
 import {of} from 'rxjs';
+import {ComplexPortalService} from '../../../../shared/service/complex-portal.service';
+import {map} from 'rxjs/operators';
 
 class EnrichedInteractor {
   interactor: Interactor;
@@ -23,7 +25,7 @@ export class TableInteractorColumnComponent implements OnInit {
   @Input() complexSearch: ComplexSearchResult;
   _enrichedInteractors: EnrichedInteractor[];
 
-  constructor() {
+  constructor(private complexPortalService: ComplexPortalService) {
   }
 
   ngOnInit() {
@@ -203,8 +205,17 @@ export class TableInteractorColumnComponent implements OnInit {
     const foundComplex: Element = this.complexSearch.elements.find(complex => complex.complexAC === interactor.interactor.identifier);
     if (!!foundComplex) {
       return of(foundComplex.components);
+    } else {
+      // Actually call the back-end to fetch these
+      return this.complexPortalService.getComplexAc(interactor.interactor.identifier)
+        .pipe(map(complex => complex.participants.map(participant => new ComplexComponent(
+          participant.identifier,
+          participant.identifierLink,
+          participant.name,
+          participant.description,
+          participant.stochiometry,
+          participant.interactorType))));
     }
-    return of();
   }
 
   private findInteractorInSubcomplex(interactor: EnrichedInteractor, interactorId: string): ComplexComponent {

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-structure.component.css
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-structure.component.css
@@ -1,5 +1,5 @@
 .complexNavigatorTable {
-  height: 600px;
+  height: 750px;
   border-collapse: separate;
   overflow: scroll;
   width: 100%;

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-structure.component.html
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-structure.component.html
@@ -6,7 +6,7 @@
   <div class="interactors">
     <cp-table-interactor-column
       [complexSearch]="complexSearch"
-      [components]="components">
+      [interactors]="interactors">
     </cp-table-interactor-column>
   </div>
 </div>

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-structure.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-structure.component.ts
@@ -10,7 +10,7 @@ import {Router} from '@angular/router';
 })
 export class TableStructureComponent implements OnInit {
   @Input() complexSearch: ComplexSearchResult;
-  _components: Set<Interactor>;
+  _interactors: Set<Interactor>;
 
   constructor(private router: Router) {
   }
@@ -18,13 +18,13 @@ export class TableStructureComponent implements OnInit {
   ngOnInit(): void {
   }
 
-  get components(): Set<Interactor> {
-    return this._components;
+  get interactors(): Set<Interactor> {
+    return this._interactors;
   }
 
   @Input()
-  set components(value: Set<Interactor>) {
-    this._components = value;
+  set interactors(value: Set<Interactor>) {
+    this._interactors = value;
   }
 
 }

--- a/src/app/complex/complex-results/complex-results.component.html
+++ b/src/app/complex/complex-results/complex-results.component.html
@@ -22,13 +22,12 @@
                  (click)="toggleDisplayType()">
         </div>
         <div class="listOfResults" *ngIf="DisplayType==false">
-          <cp-complex-list [complexSearch]="complexSearch"
-                           [components]="allComponentsInComplexSearch">
+          <cp-complex-list [complexSearch]="complexSearch">
           </cp-complex-list>
         </div>
         <div class="Complex-navigator" *ngIf="DisplayType">
           <cp-complex-navigator [complexSearch]="complexSearch"
-                                [components]="allComponentsInComplexSearch">
+                                [interactors]="allInteractorsInComplexSearch">
           </cp-complex-navigator>
         </div>
         <cp-complex-paginator [currentPageIndex]="currentPageIndex"

--- a/src/app/complex/complex-results/complex-results.component.ts
+++ b/src/app/complex/complex-results/complex-results.component.ts
@@ -22,7 +22,7 @@ export class ComplexResultsComponent implements OnInit, AfterViewInit {
   private _spicesFilter: string[];
   private _bioRoleFilter: string[];
   private _interactorTypeFilter: string[];
-  private _allComponentsInComplexSearch: Set<Interactor> = new Set<Interactor>();
+  private _allInteractorsInComplexSearch: Set<Interactor> = new Set<Interactor>();
   DisplayType = true;
 
 
@@ -34,7 +34,7 @@ export class ComplexResultsComponent implements OnInit, AfterViewInit {
 
   ngOnInit() {
     this.titleService.setTitle('Complex Portal - Results');
-    this._allComponentsInComplexSearch = new Set();
+    this._allInteractorsInComplexSearch = new Set();
 
     this.route
       .queryParams
@@ -59,12 +59,12 @@ export class ComplexResultsComponent implements OnInit, AfterViewInit {
     this.complexPortalService.findComplex(this.query, this.spicesFilter, this.bioRoleFilter,
       this.interactorTypeFilter, this.currentPageIndex, this.pageSize).subscribe(complexSearch => {
       this.complexSearch = complexSearch;
-      this._allComponentsInComplexSearch = new Set();
+      this._allInteractorsInComplexSearch = new Set();
       if (this.complexSearch.totalNumberOfResults !== 0) {
         this.lastPageIndex = Math.ceil(complexSearch.totalNumberOfResults / this.pageSize);
         for (let i = 0; i < complexSearch.elements.length; i++) {
           complexSearch.elements[i].components
-            .forEach(component => this._allComponentsInComplexSearch.add(
+            .forEach(component => this._allInteractorsInComplexSearch.add(
               new Interactor(
                 component.identifier,
                 component.identifierLink,
@@ -216,12 +216,12 @@ export class ComplexResultsComponent implements OnInit, AfterViewInit {
     this._interactorTypeFilter = value;
   }
 
-  public get allComponentsInComplexSearch(): Set<Interactor> {
-    return this._allComponentsInComplexSearch;
+  public get allInteractorsInComplexSearch(): Set<Interactor> {
+    return this._allInteractorsInComplexSearch;
   }
 
-  set allComponentsInComplexSearch(value: Set<Interactor>) {
-    this._allComponentsInComplexSearch = value;
+  set allInteractorsInComplexSearch(value: Set<Interactor>) {
+    this._allInteractorsInComplexSearch = value;
   }
 
   toggleDisplayType() {


### PR DESCRIPTION
I split the changes into multiple commits to make it easier to review.
The changes are:
1. Rename components as interactors where relevant
2. Use ng-container to have sections with a single ngIf instead of multiple ngIf with the same condition on multiple divs
3. Create EnricherInteractor to encapsulate the logic to expand subcomplexes
4. Refactor methods to get stochiometry to re-use some code, parse the stochiometry values and show ranges only when needed
5. Update EnricherInteractor to include logic to hide duplicated interactors when expanding subcomplexes
6. Call the backend when needed to fetch interactors of a subcomplex