### PR TITLE
Rename components as interactors

### DIFF
--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.ts
@@ -27,12 +27,12 @@ export class TableHeaderComponent implements OnInit {
 
     // check which complex is the biggest
     for (const complex of searchResult) {
-      let totalLength = complex.components.length;
-      for (const complexInteractorChecked of complex.components) {
+      let totalLength = complex.interactors.length;
+      for (const complexInteractorChecked of complex.interactors) {
         if (complexInteractorChecked.interactorType === 'stable complex') {
           // tslint:disable-next-line:no-shadowed-variable
           const subComplex: Element = searchResult.find(complex => complex.complexAC === complexInteractorChecked.identifier);
-          totalLength += subComplex.components.length;
+          totalLength += subComplex.interactors.length;
         }
       }
       if (totalLength > biggestComplex[1]) {
@@ -46,8 +46,8 @@ export class TableHeaderComponent implements OnInit {
     // compare the other complexes with the biggest
     for (const comparedComplex of searchResult) {
       let similarities = 0;
-      for (const biggestComplexInteractor of bigComplex.components) {
-        for (const complexInteractor of comparedComplex.components) {
+      for (const biggestComplexInteractor of bigComplex.interactors) {
+        for (const complexInteractor of comparedComplex.interactors) {
           if (biggestComplexInteractor.identifier === complexInteractor.identifier) {
             similarities++;
           }
@@ -56,10 +56,10 @@ export class TableHeaderComponent implements OnInit {
           // tslint:disable-next-line:max-line-length
           const subComplex: Element = searchResult.find(complex => complex.complexAC === biggestComplexInteractor.identifier);
           if (comparedComplex.complexAC === bigComplex.complexAC) {
-            similarities += subComplex.components.length;
+            similarities += subComplex.interactors.length;
           }
-          for (const subComponent of subComplex.components) {
-            for (const complexInteractor of comparedComplex.components) {
+          for (const subComponent of subComplex.interactors) {
+            for (const complexInteractor of comparedComplex.interactors) {
               if (subComponent.identifier === complexInteractor.identifier) {
                 similarities++;
               }

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.ts
@@ -79,7 +79,7 @@ export class TableInteractorColumnComponent implements OnInit {
   }
 
   findInteractorInComplex(complex: Element, componentId: string): ComplexComponent {
-    return complex.components.find(component => component.identifier === componentId);
+    return complex.interactors.find(component => component.identifier === componentId);
   }
 
   findInteractorsInSubComplex(complex: Element, interactorId: string): ComplexComponent[] {
@@ -88,7 +88,7 @@ export class TableInteractorColumnComponent implements OnInit {
       .filter(interactor => interactor.isSubComplex)
       // filter subcomplexes included in complex
       .filter(interactor =>
-        complex.components.some(component => component.identifier === interactor.interactor.identifier))
+        complex.interactors.some(component => component.identifier === interactor.interactor.identifier))
       // filter subcomplexes that match the componentId
       .filter(interactor => !!interactor.subComponents)
       .map(interactor => interactor.subComponents.find(subComponent => subComponent.identifier === interactorId))
@@ -96,7 +96,7 @@ export class TableInteractorColumnComponent implements OnInit {
   }
 
   public findInteractorInExpandedSubComplex(interactor: EnrichedInteractor, complex: Element, interactorId: string): ComplexComponent {
-    if (complex.components.some(component => component.identifier === interactor.interactor.identifier)) {
+    if (complex.interactors.some(component => component.identifier === interactor.interactor.identifier)) {
       return interactor.subComponents.find(component => component.identifier === interactorId);
     }
     return null;
@@ -240,7 +240,7 @@ export class TableInteractorColumnComponent implements OnInit {
     // this function returns the list of subcomponents of an interactor of type stable complex
     const foundComplex: Element = this.complexSearch.elements.find(complex => complex.complexAC === interactor.interactor.identifier);
     if (!!foundComplex) {
-      return of(foundComplex.components);
+      return of(foundComplex.interactors);
     } else {
       // Actually call the back-end to fetch these
       return this.complexPortalService.getComplexAc(interactor.interactor.identifier)
@@ -397,8 +397,8 @@ export class TableInteractorColumnComponent implements OnInit {
     // We do this to be able to draw a line connecting all interactors in the complex
     for (let i = 0; i < this._enrichedInteractors.length; i++) {
       if (!this._enrichedInteractors[i].hidden) {
-        for (let j = 0; j < complex.components.length; j++) {
-          if (complex.components[j].identifier === this._enrichedInteractors[i].interactor.identifier) {
+        for (let j = 0; j < complex.interactors.length; j++) {
+          if (complex.interactors[j].identifier === this._enrichedInteractors[i].interactor.identifier) {
             // The interactor is part of the complex, we update the start and end indices for the interactors
             // line as it may start in this interactor
             enrichedComplex.startInteractorIndex = this.getMinValue(enrichedComplex.startInteractorIndex, i);
@@ -426,7 +426,7 @@ export class TableInteractorColumnComponent implements OnInit {
             // This means the subcomponents of the subcomplex are visible, and any of them could be part of the complex.
             // In that case, the line could start or end on any of those subcomponents
             for (let k = 0; k < this._enrichedInteractors[i].subComponents.length; k++) {
-              if (complex.components[j].identifier === this._enrichedInteractors[i].subComponents[k].identifier) {
+              if (complex.interactors[j].identifier === this._enrichedInteractors[i].subComponents[k].identifier) {
                 // The subcomponent of this interactor is part of the complex, we update the start and end indices for the interactors
                 // line as it may start in this interactor
                 enrichedComplex.startInteractorIndex = this.getMinValue(enrichedComplex.startInteractorIndex, i);
@@ -494,7 +494,7 @@ export class TableInteractorColumnComponent implements OnInit {
       // If the interactor is actually part of the complex, the line starts in this interactor
       // Otherwise, the line actually starts on one of the subcomponets of the complex, but not on the interactor itself, as it is
       // not part of the complex.
-      if (complex.complex.components.some(component =>
+      if (complex.complex.interactors.some(component =>
         this._enrichedInteractors[interactorIndex].interactor.identifier === component.identifier)) {
         return true;
       }
@@ -554,7 +554,7 @@ export class TableInteractorColumnComponent implements OnInit {
         // If the subcomplex is a component of the complex, the line starts in the cell of the interactor, meaning it cannot
         // start on any subcomponent.
         // Otherwise, it starts on the subcomponent with the index subComponentIndex
-        return !complex.complex.components.some(component =>
+        return !complex.complex.interactors.some(component =>
           this._enrichedInteractors[interactorIndex].interactor.identifier === component.identifier);
 
       }
@@ -577,7 +577,7 @@ export class TableInteractorColumnComponent implements OnInit {
     for (const oneInteractor of this._enrichedInteractors) {
       let inNComplexes = 0;
       for (const complex of this.complexSearch.elements) {
-        for (const complexesInteractors of complex.components) {
+        for (const complexesInteractors of complex.interactors) {
           if (oneInteractor.interactor.identifier === complexesInteractors.identifier) {
             inNComplexes++;
           }
@@ -586,7 +586,7 @@ export class TableInteractorColumnComponent implements OnInit {
           for (const subComponent of oneInteractor.subComponents) {
             // tslint:disable-next-line:no-shadowed-variable
             for (const complex of this.complexSearch.elements) {
-              for (const complexesInteractors of complex.components) {
+              for (const complexesInteractors of complex.interactors) {
                 if (oneInteractor.interactor.identifier === complexesInteractors.identifier) {
                   inNComplexes++;
                 }

--- a/src/app/complex/complex-results/complex-results.component.ts
+++ b/src/app/complex/complex-results/complex-results.component.ts
@@ -63,7 +63,7 @@ export class ComplexResultsComponent implements OnInit, AfterViewInit {
       if (this.complexSearch.totalNumberOfResults !== 0) {
         this.lastPageIndex = Math.ceil(complexSearch.totalNumberOfResults / this.pageSize);
         for (let i = 0; i < complexSearch.elements.length; i++) {
-          for (const component of complexSearch.elements[i].components) {
+          for (const component of complexSearch.elements[i].interactors) {
             if (!this._allInteractorsInComplexSearch.some(interactor => interactor.identifier === component.identifier)) {
               this._allInteractorsInComplexSearch.push(
                 new Interactor(

--- a/src/app/complex/shared/model/complex-results/element.model.ts
+++ b/src/app/complex/shared/model/complex-results/element.model.ts
@@ -5,15 +5,15 @@ export class Element {
   private _complexName: string;
   private _organismName: string;
   private _description: string;
-  private _components: ComplexComponent[];
+  private _interactors: ComplexComponent[];
 
 
-  constructor(complexAC: string, complexName: string, organismName: string, description: string, components: ComplexComponent[]) {
+  constructor(complexAC: string, complexName: string, organismName: string, description: string, interactors: ComplexComponent[]) {
     this._complexAC = complexAC;
     this._complexName = complexName;
     this._organismName = organismName;
     this._description = description;
-    this._components = components;
+    this._interactors = interactors;
   }
 
   get complexAC(): string {
@@ -31,7 +31,7 @@ export class Element {
   get description(): string {
     return this._description;
   }
-  get components(): ComplexComponent[] {
-    return this._components;
+  get interactors(): ComplexComponent[] {
+    return this._interactors;
   }
 }


### PR DESCRIPTION
I have made some changes in the back-end, to have the interactors in SOLR so we don't need to fetch them from the DB. The field in the response is now called `interactors` instead of `components` so we need to rename it on the front-end.
 I haven't deployed it yet, but let me know when you're ready to merge this and I'll deploy the changes in the back-end.