### PR TITLE
Fix expanded shadow bug

### DIFF
--- a/src/app/complex/complex-portal-utils.ts
+++ b/src/app/complex/complex-portal-utils.ts
@@ -110,7 +110,7 @@ export function organismIcon(organism: string): string {
 }
 
 function formatOrganismName(name: string): string {
-  if (name.includes(';')) {
+  if (!!name && name.includes(';')) {
     const end = name.indexOf(';');
     return name.substring(0, end);
   }

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.css
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.css
@@ -100,6 +100,15 @@ a, a:visited {
   background: linear-gradient(0deg, #0e6f7696 0px, transparent 10px);
 }
 
+.singleExpandedRow:after {
+  z-index: 40;
+  content: '';
+  position: absolute;
+  inset: -2px -1px -2px -1px;
+  pointer-events: none;
+  background: linear-gradient(180deg, #0e6f7696 0px, transparent 10px), linear-gradient(0deg, #0e6f7696 0px, transparent 10px);
+}
+
 /* Interactors sorting label*/
 
 .interactorSeparation {

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.html
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.html
@@ -53,7 +53,7 @@
         <ng-container *ngIf="!!interactor.subComponents">
           <tr *ngFor="let el of interactor.subComponents; let j=index"
               class="expandedRows"
-              [ngClass]="{'firstExpandedRow': j === 0, 'lastExpandedRow': j === interactor.subComponents.length - 1}">
+              [ngClass]="getExpandedRowClass(j, interactor.subComponents.length)">
             <td [attr.rowspan]="interactor.subComponents.length" class="interactorSeparation"
                 title="{{interactor.interactor.name}} interactors"
                 *ngIf="j === 0 && (interactorsSorting === 'Type' || interactorsSorting === 'Organism')">

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.ts
@@ -314,4 +314,17 @@ export class TableInteractorColumnComponent implements OnChanges {
   isInteractorSortingSet() {
     return this.interactorsSorting === 'Type' || this.interactorsSorting === 'Organism';
   }
+
+  getExpandedRowClass(i: number, length: number): string {
+    if (i === 0) {
+      if (length === 1) {
+        return 'singleExpandedRow';
+      } else {
+        return 'firstExpandedRow';
+      }
+    } else if (i === length - 1) {
+      return 'lastExpandedRow';
+    }
+    return null;
+  }
 }


### PR DESCRIPTION
When there is only one component in the subcomplex, ngClass was setting the class as both `firstExpandedRow` and `lastExpandedRow`, but they were not working together.

Instead I created a new CSS class for the case when we have one subcomponent and we want the show before and after that row. To simplify the ngClass logic, I moved the logic to a method in the ts file and simply call that method from the ngClass in the HTML.

Unrelated to this, but I saw it while testing this, if the organism name was null or undefined, `formatOrganismName` was throwing an error.