### PR TITLE
Complex navigator basket improvements

### DIFF
--- a/src/app/basket/basket.component.html
+++ b/src/app/basket/basket.component.html
@@ -1,6 +1,7 @@
 <div class="margin-top-large margin-bottom-large">
   <div *ngIf="!isComplexBasketEmpty()" class="columns medium-12">
-    <h1>Personal complex collection</h1>
+    <h2>Personal collection of favourite complexes</h2>
+    <h4>{{getKeys(complexBasket).length}} complexes in your basket</h4>
     <div class="row">
       <cp-complex-list-display-buttons
         [displayType]="DisplayType"

--- a/src/app/basket/basket.component.html
+++ b/src/app/basket/basket.component.html
@@ -1,7 +1,13 @@
 <div class="margin-top-large margin-bottom-large">
   <div *ngIf="!isComplexBasketEmpty()" class="columns medium-12">
     <h1>Personal complex collection</h1>
-    <table class="hover">
+    <div class="row">
+      <cp-complex-list-display-buttons
+        [displayType]="DisplayType"
+        (displayTypeChange)="onDisplayTypeChange($event)">
+      </cp-complex-list-display-buttons>
+    </div>
+    <table class="hover" *ngIf="!this.isDisplayComplexNavigatorView()">
       <thead>
       <tr>
         <th>Name</th>
@@ -28,12 +34,20 @@
       </tr>
       </tbody>
     </table>
-    <div class="ComplexNavigator">
-      <cp-complex-navigator
-        [complexSearch]="complexSearchBasket"
-        [interactors]="allInteractorsInComplexSearchBasket">
-      </cp-complex-navigator>
-    </div>
+    <ng-container *ngIf="complexSearchBasket;else loadingSpinner">
+      <div class="ComplexNavigator" *ngIf="isDisplayComplexNavigatorView()">
+        <cp-complex-navigator
+          [complexSearch]="complexSearchBasket"
+          [interactors]="allInteractorsInComplexSearchBasket"
+          [canAddComplexesToBasket]="false"
+          [canRemoveComplexesFromBasket]="true"
+          (onComplexRemovedFromBasket)="deleteComplexFromBasket($event)">
+        </cp-complex-navigator>
+      </div>
+    </ng-container>
+    <ng-template #loadingSpinner>
+      <cp-progress-spinner></cp-progress-spinner>
+    </ng-template>
 
   </div>
   <div *ngIf="isComplexBasketEmpty()" class="columns medium-12">

--- a/src/app/basket/basket.module.ts
+++ b/src/app/basket/basket.module.ts
@@ -3,13 +3,15 @@ import {CommonModule} from '@angular/common';
 import {RouterModule} from '@angular/router';
 import {BasketComponent} from './basket.component';
 import {ComplexNavigatorModule} from '../complex/complex-results/complex-navigator/complex-navigator.module';
+import {ProgressSpinnerModule} from '../shared/loading-indicators/progress-spinner/progress-spinner.module';
 
 @NgModule({
   imports: [RouterModule.forChild([
     {path: '', component: BasketComponent}
   ]),
     CommonModule,
-    ComplexNavigatorModule
+    ComplexNavigatorModule,
+    ProgressSpinnerModule
   ],
   declarations: [BasketComponent]
 })

--- a/src/app/complex/complex-results/complex-navigator/complex-list-display-buttons/complex-list-display-buttons.component.css
+++ b/src/app/complex/complex-results/complex-navigator/complex-list-display-buttons/complex-list-display-buttons.component.css
@@ -1,0 +1,59 @@
+.displayButton {
+  text-align: center;
+  width: 100%;
+}
+
+.view-button {
+  width: 225px;
+  margin-right: 5px;
+  background-color: white;
+  color: #555;
+  border: 1px dotted #007c82;
+  float: unset;
+}
+
+.view-button:hover {
+  color: #007c82;
+  background-color: rgb(234, 234, 234);
+  border: transparent;
+  border-bottom: 1px dotted #007c82;
+}
+
+.selected,
+.selected:hover {
+  background-color: #007c82;
+  color: white;
+}
+
+.new-tag {
+  color: red;
+  font-weight: bold;
+  font-size: x-small;
+}
+
+.new-tag-selected {
+  color: yellow;
+}
+
+.cnButton {
+  outline-offset: 0;
+  outline: rgba(0, 124, 130, 0.75) solid 1px;
+  animation: animateOutline 4s ease infinite;
+}
+
+.cnButton.selected {
+  animation: none;
+}
+
+@keyframes animateOutline {
+  0%,
+  50%,
+  100% {
+    outline-width: 6px;
+    outline-offset: 4px;
+    outline-color: rgba(0, 124, 130, 0);
+  }
+  10% {
+    outline-color: rgba(0, 124, 130, 0.75);
+  }
+}

--- a/src/app/complex/complex-results/complex-navigator/complex-list-display-buttons/complex-list-display-buttons.component.html
+++ b/src/app/complex/complex-results/complex-navigator/complex-list-display-buttons/complex-list-display-buttons.component.html
@@ -1,0 +1,11 @@
+<div class="displayButton columns medium-8">
+  <button type="submit" name="submit" class="button view-button"
+          (click)="setListView()" [ngClass]="{'selected': !isDisplayComplexNavigatorView()}">
+    View list
+  </button>
+  <button type="submit" name="submit" class="button view-button cnButton"
+          (click)="setComplexNavigatorView()" [ngClass]="{'selected': isDisplayComplexNavigatorView()}">
+    View Complex Navigator
+    <span class="new-tag" [ngClass]="{'new-tag-selected': displayType === isDisplayComplexNavigatorView()}">NEW!</span>
+  </button>
+</div>

--- a/src/app/complex/complex-results/complex-navigator/complex-list-display-buttons/complex-list-display-buttons.component.spec.ts
+++ b/src/app/complex/complex-results/complex-navigator/complex-list-display-buttons/complex-list-display-buttons.component.spec.ts
@@ -1,0 +1,26 @@
+/* tslint:disable:no-unused-variable */
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ComplexListDisplayButtonsComponent } from './complex-list-display-buttons.component';
+
+describe('ComplexListDisplayButtonsComponent', () => {
+  let component: ComplexListDisplayButtonsComponent;
+  let fixture: ComponentFixture<ComplexListDisplayButtonsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ComplexListDisplayButtonsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ComplexListDisplayButtonsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/complex/complex-results/complex-navigator/complex-list-display-buttons/complex-list-display-buttons.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/complex-list-display-buttons/complex-list-display-buttons.component.ts
@@ -1,0 +1,30 @@
+import {Component, EventEmitter, Input, Output} from '@angular/core';
+
+export const LIST_VIEW = 'view_list';
+export const COMPLEX_NAVIGATOR_VIEW = 'view_complex_navigator';
+
+@Component({
+  selector: 'cp-complex-list-display-buttons',
+  templateUrl: './complex-list-display-buttons.component.html',
+  styleUrls: ['./complex-list-display-buttons.component.css']
+})
+export class ComplexListDisplayButtonsComponent {
+
+  @Input() displayType: string;
+  @Output() displayTypeChange = new EventEmitter<string>();
+
+  setListView() {
+    this.displayType = LIST_VIEW;
+    this.displayTypeChange.emit(this.displayType);
+  }
+
+  setComplexNavigatorView() {
+    this.displayType = COMPLEX_NAVIGATOR_VIEW;
+    this.displayTypeChange.emit(this.displayType);
+  }
+
+  isDisplayComplexNavigatorView(): boolean {
+    return this.displayType === COMPLEX_NAVIGATOR_VIEW;
+  }
+
+}

--- a/src/app/complex/complex-results/complex-navigator/complex-navigator.component.html
+++ b/src/app/complex/complex-results/complex-navigator/complex-navigator.component.html
@@ -12,7 +12,10 @@
                       [interactorsSorting]="interactorsSorting"
                       [organismIconDisplay]="organismIconDisplay"
                       [interactorTypeDisplay]="interactorTypeDisplay"
-                      [IDDisplay]="IDDisplay">
+                      [IDDisplay]="IDDisplay"
+                      [canAddComplexesToBasket]="canAddComplexesToBasket"
+                      [canRemoveComplexesFromBasket]="canRemoveComplexesFromBasket"
+                      (onComplexRemovedFromBasket)="onComplexRemovedFromBasket.emit($event)">
   </cp-table-structure>
 </div>
 

--- a/src/app/complex/complex-results/complex-navigator/complex-navigator.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/complex-navigator.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input} from '@angular/core';
+import {Component, EventEmitter, Input, Output} from '@angular/core';
 import {ComplexSearchResult} from '../../shared/model/complex-results/complex-search.model';
 import {Interactor} from '../../shared/model/complex-results/interactor.model';
 
@@ -11,6 +11,10 @@ import {Interactor} from '../../shared/model/complex-results/interactor.model';
 export class ComplexNavigatorComponent {
   @Input() complexSearch: ComplexSearchResult;
   @Input() interactors: Interactor[];
+  @Input() canAddComplexesToBasket: boolean;
+  @Input() canRemoveComplexesFromBasket: boolean;
+  @Output() onComplexRemovedFromBasket: EventEmitter<string> = new EventEmitter<string>();
+
   interactorsSorting = 'Occurrence';
   organismIconDisplay = true;
   interactorTypeDisplay = true;

--- a/src/app/complex/complex-results/complex-navigator/complex-navigator.module.ts
+++ b/src/app/complex/complex-results/complex-navigator/complex-navigator.module.ts
@@ -23,6 +23,7 @@ import {
 import {ComplexNavigatorButtonsComponent} from '../complex-navigator-buttons/complex-navigator-buttons.component';
 import {ProgressSpinnerModule} from '../../../shared/loading-indicators/progress-spinner/progress-spinner.module';
 import {RouterModule} from '@angular/router';
+import {ComplexListDisplayButtonsComponent} from './complex-list-display-buttons/complex-list-display-buttons.component';
 
 @NgModule({
   imports: [
@@ -32,7 +33,8 @@ import {RouterModule} from '@angular/router';
     MarkdownModule
   ],
   exports: [
-    ComplexNavigatorComponent
+    ComplexNavigatorComponent,
+    ComplexListDisplayButtonsComponent
   ],
   declarations: [
     ComplexNavigatorComponent,
@@ -44,7 +46,8 @@ import {RouterModule} from '@angular/router';
     TableInteractorStoichiometryComponent,
     TableMainInteractorComponent,
     TableSubcomponentInteractorComponent,
-    ComplexNavigatorButtonsComponent
+    ComplexNavigatorButtonsComponent,
+    ComplexListDisplayButtonsComponent
   ]
 })
 export class ComplexNavigatorModule {

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.css
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.css
@@ -41,7 +41,7 @@ thead {
   color: white;
   border-left: 1px solid white;
   font-size: medium;
-  height: 35px;
+  height: 70px;
 }
 
 .tilted-label {
@@ -105,7 +105,7 @@ thead {
   z-index: 4;
   background-color: white;
   border-bottom: 3px solid #007c82;
-  height: 35px;
+  height: 70px;
   text-align: right;
   color: #007c82;
 }
@@ -149,5 +149,10 @@ a:visited {
 
 a {
   color: white;
+}
+
+.basketButton {
+  padding: 0;
+  margin: 0;
 }
 

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.html
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.html
@@ -8,20 +8,30 @@
         Components
       </th>
       <th class="horizontal" *ngFor="let complex of complexes">
-        <a [routerLink]="['/complex', complex.complexAC]"
-           title="{{complex.complexAC}}"
-           target="_blank">
-          <div>
-            <span title="{{ complex.complexName }} - {{ complex.complexAC}}">
-              <div class="line"></div>
-                <div class="horizontal-label">
-                  <i class="{{iconOrganism(complex.organismName)}}"></i>
-                  <i class="icon icon-generic small" data-icon="x"></i>
-                  {{ complex.complexName }}
-                </div>
-            </span>
-          </div>
-        </a>
+        <div class="horizontal-label">
+          <a class="button basketButton"
+             *ngIf="canAddComplexesToBasket"
+             (click)="saveComplex(complex.complexName,complex.complexAC,complex.organismName)"
+             [ngClass]="{'disabled': isInBasket(complex.complexAC)}"><span class="icon icon-generic medium "
+                                                                           data-icon="b"></span></a>
+          <a class="button basketButton"
+             *ngIf="canRemoveComplexesFromBasket"
+             (click)="removeComplex(complex.complexAC)"
+             [ngClass]="{'disabled': !isInBasket(complex.complexAC)}"><span class="icon icon-generic medium "
+                                                                            data-icon="b"></span></a>
+          <a [routerLink]="['/complex', complex.complexAC]"
+             title="{{complex.complexAC}}"
+             target="_blank">
+            <div>
+              <span title="{{ complex.complexName }} - {{ complex.complexAC}}">
+                <div class="line"></div>
+                <i class="{{iconOrganism(complex.organismName)}}"></i>
+                <i class="icon icon-generic small" data-icon="x"></i>
+                {{ complex.complexName }}
+              </span>
+            </div>
+          </a>
+        </div>
       </th>
     </tr>
     </thead>
@@ -61,7 +71,22 @@
         Components
       </th>
       <ng-container *ngFor=" let complex of complexes;">
-        <th class="iconOrganism"><i class="{{iconOrganism(complex.organismName)}}" title="{{complex.organismName}}"></i>
+        <th class="iconOrganism">
+          <div>
+            <a class="button basketButton"
+               *ngIf="canAddComplexesToBasket"
+               (click)="saveComplex(complex.complexName,complex.complexAC,complex.organismName)"
+               [ngClass]="{'disabled': isInBasket(complex.complexAC)}"><span class="icon icon-generic medium "
+                                                                             data-icon="b"></span></a>
+            <a class="button basketButton"
+               *ngIf="canRemoveComplexesFromBasket"
+               (click)="removeComplex(complex.complexAC)"
+               [ngClass]="{'disabled': !isInBasket(complex.complexAC)}"><span class="icon icon-generic medium "
+                                                                              data-icon="b"></span></a>
+          </div>
+          <div>
+            <i class="{{iconOrganism(complex.organismName)}}" title="{{complex.organismName}}"></i>
+          </div>
         </th>
       </ng-container>
       <div class="spaceHolder" [style]="complexes.length<15 ? 'max-width: inherit;min-width: inherit':''"></div>

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.ts
@@ -1,6 +1,7 @@
-import {Component, Input} from '@angular/core';
+import {Component, EventEmitter, Input, Output} from '@angular/core';
 import {Element} from '../../../../shared/model/complex-results/element.model';
 import {organismIcon} from '../../../../complex-portal-utils';
+import {BasketService} from '../../../../../shared/basket/service/basket.service';
 
 @Component({
   selector: 'cp-table-header',
@@ -11,6 +12,12 @@ import {organismIcon} from '../../../../complex-portal-utils';
 export class TableHeaderComponent {
   @Input() complexes: Element[];
   @Input() interactorsSorting: string;
+  @Input() canAddComplexesToBasket: boolean;
+  @Input() canRemoveComplexesFromBasket: boolean;
+  @Output() onComplexRemovedFromBasket: EventEmitter<string> = new EventEmitter<string>();
+
+  constructor(private basketService: BasketService) {
+  }
 
   isInteractorSortingSet() {
     return this.interactorsSorting === 'Type' || this.interactorsSorting === 'Organism';
@@ -18,5 +25,17 @@ export class TableHeaderComponent {
 
   iconOrganism(organismName: string) {
     return organismIcon(organismName);
+  }
+
+  saveComplex(complexName: string, complexAC: string, complexOrganism: string) {
+    this.basketService.saveInBasket(complexName, complexAC, complexOrganism);
+  }
+
+  removeComplex(complexAC: string): void {
+    this.onComplexRemovedFromBasket.emit(complexAC);
+  }
+
+  isInBasket(complexAC: string): boolean {
+    return this.basketService.isInBasket(complexAC);
   }
 }

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.ts
@@ -53,7 +53,6 @@ export class TableInteractorColumnComponent implements OnChanges {
   ngOnChanges(changes: SimpleChanges): void {
     if (!!changes['interactors']) {
       this.enrichInteractors();
-      this.interactorsTimesAppearing();
       this.calculateTimesAppearing();
     }
     this.classifyInteractors();
@@ -341,21 +340,6 @@ export class TableInteractorColumnComponent implements OnChanges {
       return 'lastExpandedRow';
     }
     return null;
-  }
-
-  interactorsTimesAppearing() {
-    for (const oneInteractor of this.enrichedInteractors) {
-      for (const complex of this.complexes) {
-        const match = findInteractorInComplex(complex, oneInteractor.interactor.identifier, this.enrichedInteractors);
-        if (!!match) {
-          if (!!match.stochiometryValue) {
-            oneInteractor.timesAppearing += match.stochiometryValue[0];
-          } else {
-            oneInteractor.timesAppearing += 1;
-          }
-        }
-      }
-    }
   }
 
   private calculateTimesAppearing() {

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-structure.component.html
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-structure.component.html
@@ -3,7 +3,10 @@
        (scroll)="body.scrollLeft = header.scrollLeft" #header>
 
     <cp-table-header [complexes]="sortedComplexes"
-                     [interactorsSorting]="interactorsSorting">
+                     [interactorsSorting]="interactorsSorting"
+                     [canAddComplexesToBasket]="canAddComplexesToBasket"
+                     [canRemoveComplexesFromBasket]="canRemoveComplexesFromBasket"
+                     (onComplexRemovedFromBasket)="onComplexRemovedFromBasket.emit($event)">
     </cp-table-header>
   </div>
   <div class="interactors"

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-structure.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-structure.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnChanges} from '@angular/core';
+import {Component, EventEmitter, Input, OnChanges, Output} from '@angular/core';
 import {ComplexSearchResult} from '../../../shared/model/complex-results/complex-search.model';
 import {Interactor} from '../../../shared/model/complex-results/interactor.model';
 import {Element} from '../../../shared/model/complex-results/element.model';
@@ -16,6 +16,9 @@ export class TableStructureComponent implements OnChanges {
   @Input() organismIconDisplay: boolean;
   @Input() interactorTypeDisplay: boolean;
   @Input() IDDisplay: boolean;
+  @Input() canAddComplexesToBasket: boolean;
+  @Input() canRemoveComplexesFromBasket: boolean;
+  @Output() onComplexRemovedFromBasket: EventEmitter<string> = new EventEmitter<string>();
 
   sortedComplexes: Element[] = [];
 
@@ -53,62 +56,6 @@ export class TableStructureComponent implements OnChanges {
         .map(complex => new Set(this.getAllComponents(complex).map(c => c.identifier)));
 
     return [...components1.values()].reduce((s, c1) => components2.has(c1) ? s + 1 : s, 0);
-    // for (const complex1Interactor of complex1.interactors) {
-    //   // The interactor of complex 1 is a subcomplex
-    //   if (complex1Interactor.interactorType === 'stable complex') {
-    //     // The subcomplex is exactly complex 2, so we add the number of interactors of complex 2 to the similarities
-    //     if (complex2.complexAC === complex1Interactor.identifier) {
-    //       similarities += complex2.interactors.length;
-    //     } else {
-    //       const subComplex: Element = this.complexSearch.elements.find(
-    //         complex => complex.complexAC === complex1Interactor.identifier
-    //       );
-    //       if (!!subComplex) {
-    //         const complex2MatchingInteractor: ComplexComponent = complex2.interactors.find(
-    //           interactor => interactor.identifier === complex1Interactor.identifier
-    //         );
-    //         if (!!complex2MatchingInteractor) {
-    //           // Complex 2 also has the same subcomplex as an interactor, so we add all the interactors in the subcomplex
-    //           // to the similarities, as the two complexes have all those interactors in common
-    //           similarities += subComplex.interactors.length;
-    //         } else {
-    //           // Complex 2 does not have the same subcomplex as interactor, so we need to compare interactors
-    //           // of the subcomplex and complex 2 to find any matches
-    //           for (const subComplexInteractor of subComplex.interactors) {
-    //             for (const complex2Interactor of complex2.interactors) {
-    //               if (subComplexInteractor.identifier === complex2Interactor.identifier) {
-    //                 similarities++;
-    //               }
-    //             }
-    //           }
-    //         }
-    //       }
-    //     }
-    //   } else {
-    //     // The interactor of complex 1 is not a subcomplex
-    //     for (const complex2Interactor of complex2.interactors) {
-    //       // The interactor of complex 2 is a subcomplex
-    //       if (complex2Interactor.interactorType === 'stable complex') {
-    //         const subComplex: Element = this.complexSearch.elements.find(
-    //           complex => complex.complexAC === complex2Interactor.identifier
-    //         );
-    //         if (!!subComplex) {
-    //           // Complex 2 interactor is a subcomplex, so we need to compare the complex 1 interactor with interactors of this
-    //           // subcomplex to find any matches
-    //           for (const subComplexInteractor of subComplex.interactors) {
-    //             if (subComplexInteractor.identifier === complex1Interactor.identifier) {
-    //               similarities++;
-    //             }
-    //           }
-    //         }
-    //       } else if (complex1Interactor.identifier === complex2Interactor.identifier) {
-    //         // The interactors of complex 1 and complex 2 are not subcomplexes, and they have the same id, so we add to the similarities
-    //         similarities++;
-    //       }
-    //     }
-    //   }
-    // }
-    // return similarities;
   }
 
   classifyComplexesSimilaritiesV2(complexesList: Element[]) {
@@ -140,6 +87,14 @@ export class TableStructureComponent implements OnChanges {
             complexesOrderedSet.add(complex4);
           }
         }
+        if (complexesOrderedSet.size === this.complexSearch.elements.length) {
+          // All complexes have been added, we can return and stop the loops
+          return complexesOrderedSet;
+        }
+      }
+      if (complexesOrderedSet.size === this.complexSearch.elements.length) {
+        // All complexes have been added, we can return and stop the loops
+        return complexesOrderedSet;
       }
     }
     return complexesOrderedSet;

--- a/src/app/complex/complex-results/complex-results.component.css
+++ b/src/app/complex/complex-results/complex-results.component.css
@@ -1,40 +1,3 @@
-.displayButton {
-  text-align: center;
-  width: 78vw;
-}
-
-.view-button {
-  width: 225px;
-  margin-right: 5px;
-  background-color: white;
-  color: #555;
-  border: 1px dotted #007c82;
-  float: unset;
-}
-
-.view-button:hover {
-  color: #007c82;
-  background-color: rgb(234, 234, 234);
-  border: transparent;
-  border-bottom: 1px dotted #007c82;
-}
-
-.selected,
-.selected:hover {
-  background-color: #007c82;
-  color: white;
-}
-
-.new-tag {
-  color: red;
-  font-weight: bold;
-  font-size: x-small;
-}
-
-.new-tag-selected {
-  color: yellow;
-}
-
 .filterColumn {
   width: 15vw;
 }
@@ -43,29 +6,6 @@
   --global-margin: calc((100vw - 80rem) / -2);
   --min-margin-left: calc(-100rem * 1.17);
   margin-left: max(var(--global-margin), var(--min-margin-left));
-}
-
-.cnButton {
-  outline-offset: 0;
-  outline: rgba(0, 124, 130, 0.75) solid 1px;
-  animation: animateOutline 4s ease infinite;
-}
-
-.cnButton.selected {
-  animation: none;
-}
-
-@keyframes animateOutline {
-  0%,
-  50%,
-  100% {
-    outline-width: 6px;
-    outline-offset: 4px;
-    outline-color: rgba(0, 124, 130, 0);
-  }
-  10% {
-    outline-color: rgba(0, 124, 130, 0.75);
-  }
 }
 
 .smallCN {

--- a/src/app/complex/complex-results/complex-results.component.html
+++ b/src/app/complex/complex-results/complex-results.component.html
@@ -4,19 +4,12 @@
       <h2 class="padding-left-large leftAligned">Total number of
         results: {{ complexSearch.totalNumberOfResults }} </h2>
       <div class="row">
-        <cp-complex-navigator-rating *ngIf="DisplayType=== COMPLEX_NAVIGATOR_VIEW">
+        <cp-complex-navigator-rating *ngIf="isDisplayComplexNavigatorView()">
         </cp-complex-navigator-rating>
-        <div class="displayButton columns medium-8">
-          <button type="submit" name="submit" class="button view-button"
-                  (click)="setListView()" [ngClass]="{'selected': DisplayType === LIST_VIEW}">
-            View list
-          </button>
-          <button type="submit" name="submit" class="button view-button cnButton"
-                  (click)="setComplexNavigatorView()" [ngClass]="{'selected': DisplayType === COMPLEX_NAVIGATOR_VIEW}">
-            View Complex Navigator
-            <span class="new-tag" [ngClass]="{'new-tag-selected': DisplayType === COMPLEX_NAVIGATOR_VIEW}">NEW!</span>
-          </button>
-        </div>
+        <cp-complex-list-display-buttons
+          [displayType]="DisplayType"
+          (displayTypeChange)="onDisplayTypeChange($event)">
+        </cp-complex-list-display-buttons>
       </div>
       <div class="columns medium-4 filterColumn leftAligned">
         <cp-complex-filter *ngIf="spicesFilter && bioRoleFilter && interactorTypeFilter"
@@ -36,15 +29,17 @@
                               (onPageChange)="onPageChange($event)">
         </cp-complex-paginator>
         <div class="listOfResults">
-          <cp-complex-list *ngIf="DisplayType===LIST_VIEW"
+          <cp-complex-list *ngIf="!isDisplayComplexNavigatorView()"
                            [complexSearch]="complexSearch">
           </cp-complex-list>
         </div>
-        <div class="ComplexNavigator changingOfDisplay" *ngIf="DisplayType===COMPLEX_NAVIGATOR_VIEW"
+        <div class="ComplexNavigator changingOfDisplay" *ngIf="isDisplayComplexNavigatorView()"
              [ngClass]="complexSearch.totalNumberOfResults <=6 ? 'smallCN' : ''">
           <cp-complex-navigator class="Complex-navigator"
                                 [complexSearch]="complexSearch"
-                                [interactors]="allInteractorsInComplexSearch">
+                                [interactors]="allInteractorsInComplexSearch"
+                                [canAddComplexesToBasket]="true"
+                                [canRemoveComplexesFromBasket]="false">
           </cp-complex-navigator>
         </div>
         <cp-complex-paginator class="changingOfDisplay"

--- a/src/app/complex/complex-results/complex-results.component.ts
+++ b/src/app/complex/complex-results/complex-results.component.ts
@@ -7,6 +7,10 @@ import {Title} from '@angular/platform-browser';
 import {AnalyticsService} from '../../shared/google-analytics/service/analytics.service';
 import {Interactor} from '../shared/model/complex-results/interactor.model';
 import {NotificationService} from '../../shared/notification/service/notification.service';
+import {
+  COMPLEX_NAVIGATOR_VIEW,
+  LIST_VIEW
+} from './complex-navigator/complex-list-display-buttons/complex-list-display-buttons.component';
 
 @Component({
   selector: 'cp-complex-results',
@@ -14,8 +18,6 @@ import {NotificationService} from '../../shared/notification/service/notificatio
   styleUrls: ['./complex-results.component.css'],
 })
 export class ComplexResultsComponent implements OnInit, AfterViewInit {
-  LIST_VIEW = 'view_list';
-  COMPLEX_NAVIGATOR_VIEW = 'view_complex_navigator';
   private _query: string;
   private _complexSearch: ComplexSearchResult;
   private _spicesFilter: string[];
@@ -41,10 +43,10 @@ export class ComplexResultsComponent implements OnInit, AfterViewInit {
     this.titleService.setTitle('Complex Portal - Results');
     this._allInteractorsInComplexSearch = [];
     this.route.fragment.subscribe(fragment => {
-      if (fragment === this.COMPLEX_NAVIGATOR_VIEW) {
-        this.DisplayType = this.COMPLEX_NAVIGATOR_VIEW;
-      } else if (fragment === this.LIST_VIEW) {
-        this.DisplayType = this.LIST_VIEW;
+      if (fragment === COMPLEX_NAVIGATOR_VIEW) {
+        this.DisplayType = COMPLEX_NAVIGATOR_VIEW;
+      } else if (fragment === LIST_VIEW) {
+        this.DisplayType = LIST_VIEW;
       }
       this.route
         .queryParams
@@ -172,7 +174,7 @@ export class ComplexResultsComponent implements OnInit, AfterViewInit {
   }
 
   get currentPageIndex(): number {
-    if (this.DisplayType === this.COMPLEX_NAVIGATOR_VIEW) {
+    if (this.DisplayType === COMPLEX_NAVIGATOR_VIEW) {
       return this._navigatorCurrentPage;
     } else {
       return this._listCurrentPage;
@@ -180,7 +182,7 @@ export class ComplexResultsComponent implements OnInit, AfterViewInit {
   }
 
   set currentPageIndex(value: number) {
-    if (this.DisplayType === this.COMPLEX_NAVIGATOR_VIEW) {
+    if (this.DisplayType === COMPLEX_NAVIGATOR_VIEW) {
       this._navigatorCurrentPage = value;
     } else {
       this._listCurrentPage = value;
@@ -197,7 +199,7 @@ export class ComplexResultsComponent implements OnInit, AfterViewInit {
   }
 
   get lastPageIndex(): number {
-    if (this.DisplayType === this.COMPLEX_NAVIGATOR_VIEW) {
+    if (this.DisplayType === COMPLEX_NAVIGATOR_VIEW) {
       return this._navigatorLastPageIndex;
     } else {
       return this._listLastPageIndex;
@@ -205,7 +207,7 @@ export class ComplexResultsComponent implements OnInit, AfterViewInit {
   }
 
   set lastPageIndex(value: number) {
-    if (this.DisplayType === this.COMPLEX_NAVIGATOR_VIEW) {
+    if (this.DisplayType === COMPLEX_NAVIGATOR_VIEW) {
       this._navigatorLastPageIndex = value;
     } else {
       this._listLastPageIndex = value;
@@ -213,7 +215,7 @@ export class ComplexResultsComponent implements OnInit, AfterViewInit {
   }
 
   get pageSize(): number {
-    if (this.DisplayType === this.COMPLEX_NAVIGATOR_VIEW) {
+    if (this.DisplayType === COMPLEX_NAVIGATOR_VIEW) {
       return this._navigatorPageSize;
     } else {
       return this._listPageSize;
@@ -248,23 +250,35 @@ export class ComplexResultsComponent implements OnInit, AfterViewInit {
     return this._allInteractorsInComplexSearch;
   }
 
-  setListView() {
-    this.DisplayType = this.LIST_VIEW;
+  onDisplayTypeChange(displayType: string) {
+    if (this.DisplayType !== displayType) {
+      this.DisplayType = displayType;
+      if (displayType === LIST_VIEW) {
+        this.setListView();
+      } else if (displayType === COMPLEX_NAVIGATOR_VIEW) {
+        this.setComplexNavigatorView();
+      }
+    }
+  }
+
+  isDisplayComplexNavigatorView(): boolean {
+    return this.DisplayType === COMPLEX_NAVIGATOR_VIEW;
+  }
+
+  private setListView() {
     this.toast = this.notificationService.complexNavigatorAnnouncement();
     this.reloadPage();
   }
 
-  setComplexNavigatorView() {
-    this.DisplayType = this.COMPLEX_NAVIGATOR_VIEW;
-    this.reloadPage();
+  private setComplexNavigatorView() {
     if (!!this.toast) {
       this.notificationService.closeAnnouncement(this.toast.toastId);
       this.toast = null;
     }
+    this.reloadPage();
   }
 
-
-  setFirstDisplayType(): void {
+  private setFirstDisplayType(): void {
     if (!this.DisplayType) {
       if (this._complexSearch.totalNumberOfResults === 1) {
         const complexId = this._complexSearch.elements[0].complexAC;


### PR DESCRIPTION
I have made some changes on the integration of the navigator in the basket to help you with that so you can focus on the orthology. The changes here are to:

1. Have buttons to switch between list and navigator mode in the basket

2. Have buttons to add/remove complexes to/from the basket when using navigator mode. We may need to do some CSS/HTML changes here to make it prettier

3. Rename 'Personal complex collection' to 'Personal collection of favourite complexes', and also I have added a subheading saying 'X  complexes in your basket'.

4. Small change in `table-interactor-column.component.ts` to remove a method that was no longer needed.

5. Small changes in `table-structure.component.ts` to remove commented out code and to break the loops in `classifyComplexesSimilaritiesV2 ` when we have ordered all complexes.

I have not made CSS changes regarding the comments I have in https://github.com/Complex-Portal/complex-portal-view/pull/218 as you have been working on those and there are reasons on why you have set some CSS values that I am not aware of. There is still a couple of issues with the CSS (check the screenshots in that PR), but that's a separate thing from these changes that we can take a look at (hopefully with help from Elliot) at some point.