### PR TITLE
Complex navigator small fixes

### DIFF
--- a/src/app/basket/basket.component.css
+++ b/src/app/basket/basket.component.css
@@ -1,5 +1,3 @@
 .ComplexNavigator {
   float: left;
-  width: 100%
-  /*background-color: #6dab49;*/
 }

--- a/src/app/basket/basket.component.css
+++ b/src/app/basket/basket.component.css
@@ -1,3 +1,7 @@
 .ComplexNavigator {
   float: left;
 }
+
+.smallCN {
+  width: 100%;
+}

--- a/src/app/basket/basket.component.html
+++ b/src/app/basket/basket.component.html
@@ -35,20 +35,22 @@
       </tr>
       </tbody>
     </table>
-    <ng-container *ngIf="complexSearchBasket;else loadingSpinner">
-      <div class="ComplexNavigator" *ngIf="isDisplayComplexNavigatorView()">
-        <cp-complex-navigator
-          [complexSearch]="complexSearchBasket"
-          [interactors]="allInteractorsInComplexSearchBasket"
-          [canAddComplexesToBasket]="false"
-          [canRemoveComplexesFromBasket]="true"
-          (onComplexRemovedFromBasket)="deleteComplexFromBasket($event)">
-        </cp-complex-navigator>
-      </div>
-    </ng-container>
-    <ng-template #loadingSpinner>
-      <cp-progress-spinner></cp-progress-spinner>
-    </ng-template>
+    <div *ngIf="isDisplayComplexNavigatorView()">
+      <ng-container *ngIf="complexSearchBasket;else loadingSpinner">
+        <div class="ComplexNavigator">
+          <cp-complex-navigator
+            [complexSearch]="complexSearchBasket"
+            [interactors]="allInteractorsInComplexSearchBasket"
+            [canAddComplexesToBasket]="false"
+            [canRemoveComplexesFromBasket]="true"
+            (onComplexRemovedFromBasket)="deleteComplexFromBasket($event)">
+          </cp-complex-navigator>
+        </div>
+      </ng-container>
+      <ng-template #loadingSpinner>
+        <cp-progress-spinner></cp-progress-spinner>
+      </ng-template>
+    </div>
 
   </div>
   <div *ngIf="isComplexBasketEmpty()" class="columns medium-12">

--- a/src/app/basket/basket.component.html
+++ b/src/app/basket/basket.component.html
@@ -37,7 +37,8 @@
     </table>
     <div *ngIf="isDisplayComplexNavigatorView()">
       <ng-container *ngIf="complexSearchBasket;else loadingSpinner">
-        <div class="ComplexNavigator">
+        <div class="ComplexNavigator"
+             [ngClass]="complexSearchBasket.totalNumberOfResults <=6 ? 'smallCN' : ''">
           <cp-complex-navigator
             [complexSearch]="complexSearchBasket"
             [interactors]="allInteractorsInComplexSearchBasket"

--- a/src/app/basket/basket.component.ts
+++ b/src/app/basket/basket.component.ts
@@ -93,7 +93,7 @@ export class BasketComponent implements OnInit, AfterViewInit {
   }
 
   private createQuery(object: any): string {
-    return 'complex_id:' + Object.values(object).map((v: BasketItem) => v.id).join(',');
+    return 'complex_id: ' + Object.values(object).map((v: BasketItem) => v.id).join(',');
   }
 
   private requestComplexesForNavigator() {

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.css
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.css
@@ -51,7 +51,6 @@ thead {
   overflow: hidden;
 }
 
-
 .CN-table .tableHeadOverflow tr {
   --cols: 1;
   --intHeader: 130px;
@@ -60,6 +59,17 @@ thead {
   display: grid;
   grid-template-columns: var(--intHeader) repeat(auto-fit, 70px);
   width: calc(var(--intHeader) + 70px * var(--cols) + var(--sizeSpaceHolder));
+  overflow: hidden;
+}
+
+.CN-table .tableHeadOverflowWithSorting tr {
+  --cols: 1;
+  --intHeader: 130px;
+  --parentWidth: 100%;
+  --sizeSpaceHolder: calc(var(--parentWidth) - 70px * var(--cols) - var(--intHeader));
+  display: grid;
+  grid-template-columns: var(--intHeader) repeat(auto-fit, 70px);
+  width: calc(var(--intHeader) + 70px * var(--cols) + var(--sizeSpaceHolder) - 3ch);
   overflow: hidden;
 }
 

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.css
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.css
@@ -116,6 +116,7 @@ thead {
   background-color: white;
   border-bottom: 3px solid #007c82;
   height: 70px;
+  line-height: 70px;
   text-align: right;
   color: #007c82;
 }

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.html
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.html
@@ -9,16 +9,6 @@
       </th>
       <th class="horizontal" *ngFor="let complex of complexes">
         <div class="horizontal-label">
-          <a class="button basketButton"
-             *ngIf="canAddComplexesToBasket"
-             (click)="saveComplex(complex.complexName,complex.complexAC,complex.organismName)"
-             [ngClass]="{'disabled': isInBasket(complex.complexAC)}"><span class="icon icon-generic medium "
-                                                                           data-icon="b"></span></a>
-          <a class="button basketButton"
-             *ngIf="canRemoveComplexesFromBasket"
-             (click)="removeComplex(complex.complexAC)"
-             [ngClass]="{'disabled': !isInBasket(complex.complexAC)}"><span class="icon icon-generic medium "
-                                                                            data-icon="b"></span></a>
           <a [routerLink]="['/complex', complex.complexAC]"
              title="{{complex.complexAC}}"
              target="_blank">
@@ -31,6 +21,16 @@
               </span>
             </div>
           </a>
+          <a class="button basketButton"
+             *ngIf="canAddComplexesToBasket"
+             (click)="saveComplex(complex.complexName,complex.complexAC,complex.organismName)"
+             [ngClass]="{'disabled': isInBasket(complex.complexAC)}"><span class="icon icon-generic medium "
+                                                                           data-icon="b"></span></a>
+          <a class="button basketButton"
+             *ngIf="canRemoveComplexesFromBasket"
+             (click)="removeComplex(complex.complexAC)"
+             [ngClass]="{'disabled': !isInBasket(complex.complexAC)}"><span class="icon icon-generic medium "
+                                                                            data-icon="b"></span></a>
         </div>
       </th>
     </tr>

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.html
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.html
@@ -36,7 +36,8 @@
     </tr>
     </thead>
     <!-- When table is overflowing -->
-    <thead class="tableHeadOverflow" *ngIf="complexes.length>6">
+    <thead class="tableHeadOverflow" *ngIf="complexes.length>6"
+           [ngClass]="isInteractorSortingSet() ? 'tableHeadOverflowWithSorting' : 'tableHeadOverflow'">
     <tr [style.--cols]="complexes.length"
         [style.--intHeader]="isInteractorSortingSet() ? '156px':''"
         [style.--sizeSpaceHolder]="complexes.length>15 ? '185px':''">

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.html
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.html
@@ -29,8 +29,8 @@
           <a class="button basketButton"
              *ngIf="canRemoveComplexesFromBasket"
              (click)="removeComplex(complex.complexAC)"
-             [ngClass]="{'disabled': !isInBasket(complex.complexAC)}"><span class="icon icon-generic medium "
-                                                                            data-icon="b"></span></a>
+             [ngClass]="{'disabled': !isInBasket(complex.complexAC)}"><span class="icon icon-functional medium "
+                                                                            data-icon="d"></span></a>
         </div>
       </th>
     </tr>
@@ -82,8 +82,8 @@
             <a class="button basketButton"
                *ngIf="canRemoveComplexesFromBasket"
                (click)="removeComplex(complex.complexAC)"
-               [ngClass]="{'disabled': !isInBasket(complex.complexAC)}"><span class="icon icon-generic medium "
-                                                                              data-icon="b"></span></a>
+               [ngClass]="{'disabled': !isInBasket(complex.complexAC)}"><span class="icon icon-functional medium "
+                                                                              data-icon="d"></span></a>
           </div>
           <div>
             <i class="{{iconOrganism(complex.organismName)}}" title="{{complex.organismName}}"></i>

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.html
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.html
@@ -45,7 +45,7 @@
             ></cp-table-main-interactor>
           </td>
         </ng-container>
-        <div class="spaceHolder" *ngIf="complexes.length>6"
+        <div *ngIf="complexes.length>6"
              [ngClass]="isInteractorSortingSet() ? 'spaceHolderWithSorting' : 'spaceHolder'"></div>
       </tr>
       <!-- Expandable menu for subcomplexes -->

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-structure.component.css
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-structure.component.css
@@ -1,7 +1,6 @@
 .complexNavigatorTable {
   border-collapse: separate;
   height: 100%;
-  width: 100%;
 }
 
 .header {

--- a/src/app/complex/complex-results/complex-results.component.css
+++ b/src/app/complex/complex-results/complex-results.component.css
@@ -4,17 +4,25 @@
 
 .leftAligned {
   --global-margin: calc((100vw - 80rem) / -2);
-  --min-margin-left: calc(-100rem * 0.17);
+  --min-margin-left: calc(-100rem * 0.3);
   margin-left: max(var(--global-margin), var(--min-margin-left));
 }
 
 .smallCN {
-  width: 55vw;
-  float: right;
+  width: 55vw !important;
+}
+
+.largeCN {
+  width: 67vw !important;
+}
+
+.ComplexNavigator {
+  float: left;
+  margin-right: -2vw;
   margin-left: auto;
 }
 
-.changingOfDisplay {
+.paginator {
   float: left;
   width: 75vw;
   margin-right: -2vw;

--- a/src/app/complex/complex-results/complex-results.component.html
+++ b/src/app/complex/complex-results/complex-results.component.html
@@ -23,7 +23,7 @@
         </cp-complex-filter>
       </div>
       <div class="columns medium-8">
-        <cp-complex-paginator class="changingOfDisplay"
+        <cp-complex-paginator class="paginator"
                               [currentPageIndex]="currentPageIndex"
                               [lastPageIndex]="lastPageIndex"
                               (onPageChange)="onPageChange($event)">
@@ -33,8 +33,8 @@
                            [complexSearch]="complexSearch">
           </cp-complex-list>
         </div>
-        <div class="ComplexNavigator changingOfDisplay" *ngIf="isDisplayComplexNavigatorView()"
-             [ngClass]="complexSearch.totalNumberOfResults <=6 ? 'smallCN' : ''">
+        <div class="ComplexNavigator" *ngIf="isDisplayComplexNavigatorView()"
+             [ngClass]="complexSearch.totalNumberOfResults <=6 ? 'smallCN' : 'largeCN'">
           <cp-complex-navigator class="Complex-navigator"
                                 [complexSearch]="complexSearch"
                                 [interactors]="allInteractorsInComplexSearch"
@@ -42,7 +42,7 @@
                                 [canRemoveComplexesFromBasket]="false">
           </cp-complex-navigator>
         </div>
-        <cp-complex-paginator class="changingOfDisplay"
+        <cp-complex-paginator class="paginator"
                               [currentPageIndex]="currentPageIndex"
                               [lastPageIndex]="lastPageIndex"
                               (onPageChange)="onPageChange($event)"></cp-complex-paginator>

--- a/src/app/complex/complex-results/complex-results.component.ts
+++ b/src/app/complex/complex-results/complex-results.component.ts
@@ -195,8 +195,7 @@ export class ComplexResultsComponent implements OnInit, AfterViewInit {
 
   set complexSearch(value: ComplexSearchResult) {
     this._complexSearch = value;
-    this.redirectToComplexDetailsPageIfOneResult();
-    this.setFirstDisplayType();
+    this.processSearchResults();
   }
 
   get lastPageIndex(): number {
@@ -279,7 +278,7 @@ export class ComplexResultsComponent implements OnInit, AfterViewInit {
     this.reloadPage();
   }
 
-  redirectToComplexDetailsPageIfOneResult(): void {
+  processSearchResults(): void {
     // No filters and only one result, then we redirect to complex details page
     // This allows users to enable filters to see even one result without redirecting them out from the results page,
     // but we ensure redirection of a new search has only one result.
@@ -292,11 +291,7 @@ export class ComplexResultsComponent implements OnInit, AfterViewInit {
         };
         this.router.navigate(['/complex', complexId]);
       }
-    }
-  }
-
-  private setFirstDisplayType(): void {
-    if (!this.DisplayType) {
+    } else if (!this.DisplayType) {
       // Currently the list view is the default, as we are just launching the navigator view
       // Later on we can change the default view to be the list or navigator view based on number of results
       if (this._complexSearch.totalNumberOfResults <= this._navigatorPageSize) {

--- a/src/app/complex/complex-results/complex-results.component.ts
+++ b/src/app/complex/complex-results/complex-results.component.ts
@@ -195,6 +195,7 @@ export class ComplexResultsComponent implements OnInit, AfterViewInit {
 
   set complexSearch(value: ComplexSearchResult) {
     this._complexSearch = value;
+    this.redirectToComplexDetailsPageIfOneResult();
     this.setFirstDisplayType();
   }
 
@@ -278,25 +279,30 @@ export class ComplexResultsComponent implements OnInit, AfterViewInit {
     this.reloadPage();
   }
 
+  redirectToComplexDetailsPageIfOneResult(): void {
+    // No filters and only one result, then we redirect to complex details page
+    // This allows users to enable filters to see even one result without redirecting them out from the results page,
+    // but we ensure redirection of a new search has only one result.
+    if (this.getFilterCount() === 0 && this._complexSearch.totalNumberOfResults === 1) {
+      const complexId = this._complexSearch.elements[0].complexAC;
+      if (!!complexId) {
+        // For some reason this is needed so the navigate call works
+        this.router.routeReuseStrategy.shouldReuseRoute = function () {
+          return false;
+        };
+        this.router.navigate(['/complex', complexId]);
+      }
+    }
+  }
+
   private setFirstDisplayType(): void {
     if (!this.DisplayType) {
-      if (this._complexSearch.totalNumberOfResults === 1) {
-        const complexId = this._complexSearch.elements[0].complexAC;
-        if (!!complexId) {
-          // For some reason this is needed so the navigate call works
-          this.router.routeReuseStrategy.shouldReuseRoute = function () {
-            return false;
-          };
-          this.router.navigate(['/complex', complexId]);
-        }
+      // Currently the list view is the default, as we are just launching the navigator view
+      // Later on we can change the default view to be the list or navigator view based on number of results
+      if (this._complexSearch.totalNumberOfResults <= this._navigatorPageSize) {
+        this.setComplexNavigatorView();
       } else {
-        // Currently the list view is the default, as we are just launching the navigator view
-        // Later on we can change the default view to be the list or navigator view based on number of results
-        if (this._complexSearch.totalNumberOfResults <= this._navigatorPageSize) {
-          this.setComplexNavigatorView();
-        } else {
-          this.setListView();
-        }
+        this.setListView();
       }
     }
   }


### PR DESCRIPTION
There are 2 changes here.

## 1. Redirect bug

Currently we are checking if displayType is set to redirect or not, assuming for new searches it won't be set. However, if people search while they are already in the search results page, then the component is already initialised, displayType is set and there is no redirection, even if there is only one result.

This fix checks if there is any filter enabled before doing the redirection. The logic is, for new searches, filters are not set, and if there's one result, we redirect. If people search, there are multiple results, and then they use filters to just have 1, this check still prevents redirection.

## 2. Small style changes

Small changes to the margins and width of the search results. I've checked these changes in Chrome, but not on other browsers, so check that before merging.

There is still one thing pending before we can merge all the basket changes to develop and release them, which is the add/remove button in complex navigator. I just added it there without much though on the position and style, so we should review it.