### PR TITLE
Sort complexes to always display curated first

### DIFF
--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.ts
@@ -88,7 +88,8 @@ export class TableInteractorColumnComponent implements OnChanges {
         subComponents: null,
         partOfComplex: [],
         timesAppearing: 0,
-        indexAppearing: this.complexes().findIndex(complex => complex.componentAcs.has(interactor.identifier))
+        indexAppearing: this.complexes().findIndex(complex =>
+          !!complex.componentAcs && complex.componentAcs.has(interactor.identifier))
       };
       if (isSubComplex) {
         this.loadSubInteractors(newEnrichedInteractor).subscribe(subComponents => newEnrichedInteractor.subComponents = subComponents);

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-structure.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-structure.component.ts
@@ -55,16 +55,25 @@ export class TableStructureComponent {
   }
 
   classifyComplexesSimilaritiesV2(complexesList: Element[]) {
-    const comparedComplexes: [Element, Element, number][] = [];
+    const comparedCuratedComplexes: [Element, Element, number][] = [];
+    const comparedPredictedComplexes: [Element, Element, number][] = [];
     for (const complex of complexesList) {
       for (const comparedComplex of complexesList) {
         // for unique comparison
         if (complex.complexAC >= comparedComplex.complexAC) {
-          comparedComplexes.push([complex, comparedComplex, this.calculateSimilarity(complex, comparedComplex)]);
+          // We always display curated complexes first, so we only compare curated vs curated and predicted vs predicted
+          if (complex.predictedComplex && comparedComplex.predictedComplex) {
+            comparedPredictedComplexes.push([complex, comparedComplex, this.calculateSimilarity(complex, comparedComplex)]);
+          } else if (!complex.predictedComplex && !comparedComplex.predictedComplex) {
+            comparedCuratedComplexes.push([complex, comparedComplex, this.calculateSimilarity(complex, comparedComplex)]);
+          }
         }
       }
     }
-    comparedComplexes.sort((a, b) => b[2] - a[2]); // sorting by similarityScore
+    comparedCuratedComplexes.sort((a, b) => b[2] - a[2]); // sorting by similarityScore
+    comparedPredictedComplexes.sort((a, b) => b[2] - a[2]); // sorting by similarityScore
+    // Single array with all curated complexes first (sorted) and then all predicted complexes (sorted)
+    const comparedComplexes: [Element, Element, number][] = [...comparedCuratedComplexes, ...comparedPredictedComplexes];
     const complexesOrderedSet = this.uniqueComplexesListOrderedBySimilarity(comparedComplexes);
     // to be used in the table as a 1D array
     return Array.from(complexesOrderedSet);


### PR DESCRIPTION
From the NAR paper (https://docs.google.com/document/d/1hZj-HhGyn6BuWfK9_9GaEQA7Xl15nTpDFq2VNwhqyBI/edit) Sucharita is writing:
```
Search results in the Navigator View display manually curated complexes first,
and ordered such that complexes with the most components are listed first.
```
It is described we display curated complexes before predicted complexes in the navigator view.

And Henning also commented on that, saying it is not the current behaviour, but it should be:
```
not currently, but hopefully this will be implemented?
```

I have made some changes to make it behave like that and this is how it looks for a search like `Q8TAD8 Q96A72 Q9H307 P38919 Q6NUS6` (https://complex-portal.github.io/complex-portal-view/complex/search?query=Q8TAD8%20Q96A72%20Q9H307%20P38919%20Q6NUS6&page=1). 

#### Current order (in develop branch, deployed in the github pages)
<img width="1092" alt="Screenshot 2024-09-04 at 12 13 01" src="https://github.com/user-attachments/assets/d3079097-7ac5-4174-852a-4b7322342c53">

#### New order
<img width="1096" alt="Screenshot 2024-09-04 at 12 13 14" src="https://github.com/user-attachments/assets/61dbb949-f47d-4aa0-914a-fbc0a0831eb2">
