### PR TITLE
Improve clustering

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "ts-helpers": "^1.1.2",
     "ts-md5": "^1.2.4",
     "tslib": "^2.0.0",
-    "zone.js": "~0.14.10"
+    "zone.js": "~0.14.10",
+    "@tensorflow/tfjs": "^4.21.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^18.1.4",

--- a/src/app/complex/complex-results/complex-navigator/complex-navigator.module.ts
+++ b/src/app/complex/complex-results/complex-navigator/complex-navigator.module.ts
@@ -25,6 +25,8 @@ import {RouterModule} from '@angular/router';
 import {ComplexListDisplayButtonsComponent} from './complex-list-display-buttons/complex-list-display-buttons.component';
 import {MatTooltipModule} from '@angular/material/tooltip';
 import {ProgressSpinnerComponent} from '../../../shared/loading-indicators/progress-spinner/progress-spinner.component';
+import {ComplexModule} from '../../complex.module';
+import {SpeciesPipe} from '../../shared/pipe/species.pipe';
 
 @NgModule({
   imports: [
@@ -32,7 +34,9 @@ import {ProgressSpinnerComponent} from '../../../shared/loading-indicators/progr
     CommonModule,
     ProgressSpinnerComponent,
     MarkdownModule,
-    MatTooltipModule
+    MatTooltipModule,
+    ComplexModule,
+    SpeciesPipe
   ],
   exports: [
     ComplexNavigatorComponent,

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.html
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.html
@@ -67,12 +67,18 @@
       <ng-container *ngFor=" let complex of complexes();">
         <th class="iconOrganism" [class.predicted]="complex.predictedComplex">
           <div>
-            <a class="button" (click)="toggleBasket(complex)">
-              <i class="icon icon-common" [attr.data-icon]="isInBasket(complex.complexAC) ? '':''"></i>
-            </a>
+            @if (isInBasket(complex.complexAC)) {
+              <a class="button" (click)="toggleBasket(complex)" [matTooltip]="'Remove from basket'">
+                <i class="icon icon-common" data-icon=""></i>
+              </a>
+            } @else {
+              <a class="button" (click)="toggleBasket(complex)" [matTooltip]="'Add to basket'">
+                <i class="icon icon-common" data-icon=""></i>
+              </a>
+            }
           </div>
           <div>
-            <i class="{{iconOrganism(complex.organismName)}}" [matTooltip]="complex.organismName"></i>
+            <i class="{{iconOrganism(complex.organismName)}}" [matTooltip]="complex.organismName | species"></i>
           </div>
         </th>
       </ng-container>

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.html
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.html
@@ -6,9 +6,13 @@
       <tr *ngIf="!interactor.hidden">
         <ng-container *ngFor="let oneType of ranges" class="interactorsOrdering">
           <td *ngIf="oneType[2]===i" [attr.rowspan]="oneType[1]" class="interactorSeparation"
-              [matTooltip]="oneType[0]">
+              [matTooltip]="interactorsSorting() === 'Organism' ? (oneType[0] | species) : oneType[0]">
             <div class="interactorNameContainer" [style.--rowspanSize]="oneType[1]">
-              {{ oneType[0] }}
+              @if (interactorsSorting() === 'Organism') {
+                {{ oneType[0] | species:true }}
+              } @else {
+                {{ oneType[0] }}
+              }
             </div>
           </td>
         </ng-container>

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.ts
@@ -247,47 +247,16 @@ export class TableInteractorColumnComponent implements OnChanges {
   }
 
   public classifyInteractorsByOrganism() {
-    this.enrichedInteractors.sort((a, b) => {
-      if (b.interactor.organismName === a.interactor.organismName) {
-        return b.timesAppearing - a.timesAppearing;
-      } else {
-        const organismBTimesAppearing = this._timesAppearingByOrganism.get(b.interactor.organismName);
-        const organismATimesAppearing = this._timesAppearingByOrganism.get(a.interactor.organismName);
-        if (organismBTimesAppearing === organismATimesAppearing) {
-          return b.interactor.organismName.localeCompare(a.interactor.organismName);
-        } else {
-          return organismBTimesAppearing - organismATimesAppearing;
-        }
-      }
-    });
-    this.rangeOfInteractorOrganism();
+    this.enrichedInteractors.sort((a, b) => b.interactor.organismName.localeCompare(a.interactor.organismName) || this.compareFn(a, b));
+    this.calculateRangesBy('organismName');
   }
 
   public classifyInteractorsByType() {
-    this.enrichedInteractors.sort((a, b) => {
-      if (b.interactor.interactorType === a.interactor.interactorType) {
-        return b.timesAppearing - a.timesAppearing;
-      } else {
-        const typeBTimesAppearing = this._timesAppearingByType.get(b.interactor.interactorType);
-        const typeATimesAppearing = this._timesAppearingByType.get(a.interactor.interactorType);
-        if (typeBTimesAppearing === typeATimesAppearing) {
-          return b.interactor.interactorType.localeCompare(a.interactor.interactorType);
-        } else {
-          return typeBTimesAppearing - typeATimesAppearing;
-        }
-      }
-    });
-    this.rangeOfInteractorType();
+    this.enrichedInteractors.sort((a, b) => b.interactor.interactorType.localeCompare(a.interactor.interactorType) || this.compareFn(a, b));
+    this.calculateRangesBy('interactorType');
   }
 
-  public classifyInteractorsByOccurrence() {
-    this.enrichedInteractors.sort((a, b) =>
-      b.timesAppearing - a.timesAppearing
-    );
-    this.ranges = [];
-  }
-
-  public rangeOfInteractorType() {
+  public calculateRangesBy(key: keyof Interactor) {
     const ranges = [];  // [type of interactor, first occurrence, last occurrence, length of the occurrence]
     let length = 0;
     let start = null;
@@ -301,9 +270,9 @@ export class TableInteractorColumnComponent implements OnChanges {
       }
       if (!this.enrichedInteractors[i + 1]
         || (this.enrichedInteractors[i].isSubComplex && this.enrichedInteractors[i].expanded)
-        || this.enrichedInteractors[i].interactor.interactorType !== this.enrichedInteractors[i + 1].interactor.interactorType) {
+        || this.enrichedInteractors[i].interactor[key] !== this.enrichedInteractors[i + 1].interactor[key]) {
         if (start !== null) {
-          oneType.push(this.enrichedInteractors[i].interactor.interactorType, length, start);
+          oneType.push(this.enrichedInteractors[i].interactor[key], length, start);
           ranges.push(oneType);
           start = null;
         }

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-name/table-interactor-name.component.html
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-name/table-interactor-name.component.html
@@ -2,13 +2,14 @@
   <div class="nameAndIcons" [ngClass]="{inlineDisplay: interactorType()==='stable complex'}">
     <i *ngIf="organismIconDisplay()"
        class="{{interactorOrganismIcon}}"
-       [matTooltip]="interactorOrganism()"></i>
+       [matTooltip]="interactorOrganism() | species"></i>
 
     <i *ngIf="interactorTypeDisplay()"
        class="{{interactorTypeIcon}}"
        [matTooltip]="interactorType()"></i>
 
-    <div class="name" *ngIf="idDisplay()" [matTooltip]="interactorId()"> {{ interactorName() }}
+    <div class="name" *ngIf="idDisplay()" [matTooltip]="interactorName()">
+      {{ interactorName() }}
     </div>
     <a *ngIf="idDisplay()"
        [routerLink]="['/complex/search']"
@@ -20,7 +21,7 @@
 
     <div class="nameCompact" *ngIf="!idDisplay()">
       <div class="name" *ngIf="!idDisplay()" [matTooltip]="'More information about ' + interactorName()">
-        <a *ngIf="!!identifierLink()" href="{{identifierLink()}}" target="_blank" class="externalLinkContainer">
+        <a *ngIf="!!identifierLink()" [href]="identifierLink()" target="_blank" class="externalLinkContainer">
           {{ interactorName() }}
         </a>
       </div>

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-structure.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-structure.component.ts
@@ -1,8 +1,9 @@
-import {Component, OnChanges, output, input, computed} from '@angular/core';
+import {Component, computed, input, output} from '@angular/core';
 import {ComplexSearchResult} from '../../../shared/model/complex-results/complex-search.model';
 import {Interactor} from '../../../shared/model/complex-results/interactor.model';
 import {Element} from '../../../shared/model/complex-results/element.model';
 import {ComplexComponent} from '../../../shared/model/complex-results/complex-component.model';
+import * as tf from '@tensorflow/tfjs';
 
 @Component({
   selector: 'cp-table-structure',
@@ -20,10 +21,32 @@ export class TableStructureComponent {
   canRemoveComplexesFromBasket = input<boolean>();
   onComplexRemovedFromBasket = output<string>();
 
-  sortedComplexes = computed(() => this.classifyComplexesSimilaritiesV2(this.complexSearch().elements));
+  sortedComplexes = computed(() => this.sortComplexBySimilarityClustering(this.complexSearch().elements));
 
   private getComponentAsComplex(component: ComplexComponent): Element | undefined {
     return this.complexSearch().elements.find(interactor => interactor.complexAC === component.identifier);
+  }
+
+  private calculateSimilarity(complex1: Element, complex2: Element) {
+    if (complex1 === complex2) {
+      return 1;
+    }
+
+    // Make predicted complex completely different to curated
+    if (complex1.predictedComplex !== complex2.predictedComplex) {
+      return -1;
+    }
+
+    const [components1, components2] = [complex1, complex2].map(this.getComponents.bind(this));
+    // @ts-ignore
+    return components1.intersection(components2).size / components1.union(components2).size;
+  }
+
+  private getComponents(complex: Element): Set<string> {
+    if (!complex.componentAcs) {
+      complex.componentAcs = new Set<string>(this.getAllComponents(complex).map(component => component.identifier));
+    }
+    return complex.componentAcs;
   }
 
   private getAllComponents(complex?: Element, components: ComplexComponent[] = []): ComplexComponent[] {
@@ -42,57 +65,49 @@ export class TableStructureComponent {
     return components;
   }
 
-  private calculateSimilarity(complex1: Element, complex2: Element) {
-    if (complex1 === complex2) {
-      return new Set(this.getAllComponents(complex1)).size;
-    }
-
-    const [components1, components2] =
-      [complex1, complex2]
-        .map(complex => new Set(this.getAllComponents(complex).map(c => c.identifier)));
-
-    return [...components1.values()].reduce((s, c1) => components2.has(c1) ? s + 1 : s, 0);
+  sortComplexBySimilarityClustering(complexesList: Element[]) {
+    const sm: number[][] = new Array(complexesList.length).fill(null).map(r => new Array(complexesList.length).fill(null));
+    complexesList.forEach((complex, i) => complexesList.forEach((comparedComplex, j) => {
+      if (i >= j) {
+        sm[i][j] = this.calculateSimilarity(complex, comparedComplex);
+        sm[j][i] = sm[i][j];
+      }
+    }));
+    const simMat = tf.tensor2d(sm);
+    return this.getSortedIndexFromChainedSimilarity(simMat).map(i => complexesList[i]);
   }
 
-  classifyComplexesSimilaritiesV2(complexesList: Element[]) {
-    const comparedComplexes: [Element, Element, number][] = [];
-    for (const complex of complexesList) {
-      for (const comparedComplex of complexesList) {
-        // for unique comparison
-        if (complex.complexAC >= comparedComplex.complexAC) {
-          comparedComplexes.push([complex, comparedComplex, this.calculateSimilarity(complex, comparedComplex)]);
-        }
-      }
-    }
-    comparedComplexes.sort((a, b) => b[2] - a[2]); // sorting by similarityScore
-    const complexesOrderedSet = this.uniqueComplexesListOrderedBySimilarity(comparedComplexes);
-    // to be used in the table as a 1D array
-    return Array.from(complexesOrderedSet);
-  }
+  /**
+   * Uses a similarity matrix to order elements based on how similar one element is to the previous element on the list.<br>
+   * Inspired by https://stackoverflow.com/a/64338609
+   *
+   * @param sm A similarity matrix to be sorted
+   * @returns indexes of elements ordered according to their similarity
+   */
+  getSortedIndexFromChainedSimilarity(sm: tf.Tensor2D): number[] {
+    const idx: number[] = [];
+    let currentIdx = tf.argMax(sm.sum(0)).arraySync() as number;  // Start with complex with most similarities
+    idx.push(currentIdx);
 
-  uniqueComplexesListOrderedBySimilarity(complexesListSimilarities: [Element, Element, number][]) {
-    const complexesOrderedSet = new Set<Element>();
-    for (let i = 0; i < complexesListSimilarities.length; i++) {
-      const [complex1, complex2, similarityScore] = complexesListSimilarities[i];
-      if (similarityScore !== 0) {
-        complexesOrderedSet.add(complex1);
-        complexesOrderedSet.add(complex2);
-        for (let j = i + 1; j < complexesListSimilarities.length; j++) {
-          const [complex3, complex4, similarityScore2nd] = complexesListSimilarities[j];
-          if (complex1 === complex3 && similarityScore2nd !== 0) {
-            complexesOrderedSet.add(complex4);
-          }
-        }
-        if (complexesOrderedSet.size === this.complexSearch().elements.length) {
-          // All complexes have been added, we can return and stop the loops
-          return complexesOrderedSet;
-        }
+    for (let i = 1; i < sm.shape[0]; i++) {
+      // Mask already selected indices
+      const buffer = sm.bufferSync();
+      for (let x = 0; x < sm.shape[0]; x++) {
+        buffer.set(-Infinity, x, currentIdx);
       }
-      if (complexesOrderedSet.size === this.complexSearch().elements.length) {
-        // All complexes have been added, we can return and stop the loops
-        return complexesOrderedSet;
+      sm = buffer.toTensor();
+
+      // Find the closest complex to last selected
+      const sm_i = sm.gather([currentIdx]).arraySync()[0] as number[];
+      currentIdx = tf.argMax(sm_i).arraySync() as number;
+
+      // If no similar entities (cluster ends), take the next complex with most similarities
+      if (sm_i[currentIdx] === 0) {
+        currentIdx = tf.argMax(sm.sum(0)).arraySync() as number;
       }
+
+      idx.push(currentIdx);
     }
-    return complexesOrderedSet;
+    return idx;
   }
 }

--- a/src/app/complex/complex-results/complex-results.module.ts
+++ b/src/app/complex/complex-results/complex-results.module.ts
@@ -12,6 +12,7 @@ import {MatTooltipModule} from '@angular/material/tooltip';
 import {ComplexModule} from '../complex.module';
 import {ProgressSpinnerComponent} from '../../shared/loading-indicators/progress-spinner/progress-spinner.component';
 import {TruncatePipe} from '../../shared/truncate/truncate.pipe';
+import {SpeciesPipe} from '../shared/pipe/species.pipe';
 
 
 @NgModule({
@@ -20,7 +21,7 @@ import {TruncatePipe} from '../../shared/truncate/truncate.pipe';
     ]),
         CommonModule,
         ProgressSpinnerComponent, MarkdownModule,
-        ComplexNavigatorModule, MatTooltipModule, ComplexModule, TruncatePipe
+        ComplexNavigatorModule, MatTooltipModule, ComplexModule, TruncatePipe, SpeciesPipe
     ],
   exports: [],
   declarations: [ComplexResultsComponent,

--- a/src/app/complex/complex.module.ts
+++ b/src/app/complex/complex.module.ts
@@ -1,7 +1,6 @@
 import {NgModule} from '@angular/core';
 import {APP_BASE_HREF, CommonModule, PlatformLocation} from '@angular/common';
 import {RouterModule} from '@angular/router';
-import { SpeciesPipe } from './shared/pipe/species.pipe';
 
 @NgModule({
   imports: [RouterModule.forChild([
@@ -27,12 +26,6 @@ import { SpeciesPipe } from './shared/pipe/species.pipe';
       deps: [PlatformLocation]
     }
   ],
-  exports: [
-    SpeciesPipe
-  ],
-  declarations: [
-    SpeciesPipe
-  ]
 })
 export class ComplexModule {
 }

--- a/src/app/complex/shared/model/complex-results/element.model.ts
+++ b/src/app/complex/shared/model/complex-results/element.model.ts
@@ -6,5 +6,6 @@ export interface Element {
   organismName: string;
   description: string;
   interactors: ComplexComponent[];
+  componentAcs?: Set<string>;
   predictedComplex?: boolean;
 }

--- a/src/app/complex/shared/pipe/species.pipe.ts
+++ b/src/app/complex/shared/pipe/species.pipe.ts
@@ -2,7 +2,8 @@ import {Pipe, PipeTransform} from '@angular/core';
 
 @Pipe({
   name: 'species',
-  pure: true
+  pure: true,
+  standalone: true,
 })
 export class SpeciesPipe implements PipeTransform {
   exceptions = new Map<string, string>([

--- a/tslint.json
+++ b/tslint.json
@@ -9,7 +9,7 @@
       true,
       "check-space"
     ],
-    "curly": true,
+    "curly": false,
     "eofline": true,
     "forin": true,
     "deprecation": {
@@ -35,8 +35,6 @@
       true,
       "debug",
       "info",
-      "time",
-      "timeEnd",
       "trace"
     ],
     "no-construct": true,


### PR DESCRIPTION
In reaction to #229 , I reimplemented the clustering of elements by following https://stackoverflow.com/a/64338609

Performances are a bit impacted, but still acceptable (roughly 200ms to sort complexes).
Improvements are particularly visible when several well identified clusters are visible, like with `Q06217 Q14974 Q16514 Q16552 Q16594 Q24572 Q4VC05 Q60973` on 
https://complex-portal.github.io/complex-portal-view/complex/search?query=Q06217%20Q14974%20Q16514%20Q16552%20Q16594%20Q24572%20Q4VC05%20Q60973#view_navigator
compared to http://localhost:4200/complex/search?query=Q8TAD8%20Q96A72%20Q9H307%20P38919%20Q6NUS6#view_navigator

The order of elements are now firstly sorted by which complex they appear in first, so that clusters are more compacted. Then I use the timeAppearing, but in the other direction than before: the least commons elements are first, then come the most common ones. That is an arguable decision, but it allows us to limit long lines. Could be something to do UX testing on to see what people prefer, because this makes cluster appear lower on the page.