### PR TITLE
:sparkles: Set measures of rotation based on angle, width and height of the tilted headers

### DIFF
--- a/src/app/basket/basket.component.html
+++ b/src/app/basket/basket.component.html
@@ -10,7 +10,7 @@
       </h2>
       <h4>{{ getKeys(complexBasket).length }} complexes in your basket</h4>
       <div class="row expanded">
-        <mat-tab-group [tabIndex]="displayType === SearchDisplay.list ? 0 : 1"
+        <mat-tab-group [tabIndex]="displayType === SearchDisplay.list ? 0 : 1" #tabs
                        (selectedTabChange)="onDisplayTypeChange($event.index === 0 ? SearchDisplay.list : SearchDisplay.navigator)"
                        class="columns medium-centered small-12 medium-10 large-8">
           <mat-tab label="List view">

--- a/src/app/basket/basket.component.html
+++ b/src/app/basket/basket.component.html
@@ -43,7 +43,6 @@
             </table>
           </mat-tab>
           <mat-tab label="Navigator view">
-            <div class="columns medium-12">
               @if (complexSearchBasket) {
                 <div class="ComplexNavigator"
                      [ngClass]="complexSearchBasket.totalNumberOfResults <=6 ? 'smallCN' : ''">
@@ -56,7 +55,6 @@
               } @else {
                 <cp-progress-spinner></cp-progress-spinner>
               }
-            </div>
           </mat-tab>
         </mat-tab-group>
       </div>

--- a/src/app/basket/basket.component.html
+++ b/src/app/basket/basket.component.html
@@ -12,7 +12,7 @@
       <div class="row expanded">
         <mat-tab-group [tabIndex]="displayType === SearchDisplay.list ? 0 : 1"
                        (selectedTabChange)="onDisplayTypeChange($event.index === 0 ? SearchDisplay.list : SearchDisplay.navigator)"
-                       class="columns medium-centered small-12 medium-10 large-8">
+                       class="columns medium-centered small-12 medium-10 large-10">
           <mat-tab label="List view">
             <table class="hover">
               <thead>

--- a/src/app/basket/basket.component.html
+++ b/src/app/basket/basket.component.html
@@ -10,7 +10,7 @@
       </h2>
       <h4>{{ getKeys(complexBasket).length }} complexes in your basket</h4>
       <div class="row expanded">
-        <mat-tab-group [tabIndex]="displayType === SearchDisplay.list ? 0 : 1" #tabs
+        <mat-tab-group [tabIndex]="displayType === SearchDisplay.list ? 0 : 1"
                        (selectedTabChange)="onDisplayTypeChange($event.index === 0 ? SearchDisplay.list : SearchDisplay.navigator)"
                        class="columns medium-centered small-12 medium-10 large-10">
           <mat-tab label="List view">

--- a/src/app/basket/basket.component.ts
+++ b/src/app/basket/basket.component.ts
@@ -1,4 +1,4 @@
-import {AfterViewInit, Component, OnInit} from '@angular/core';
+import {AfterViewInit, Component, OnInit, ViewChild} from '@angular/core';
 import {BasketService} from '../shared/basket/service/basket.service';
 import {BasketItem} from '../shared/basket/model/basketItem';
 import {ProgressBarComponent} from '../shared/loading-indicators/progress-bar/progress-bar.component';
@@ -11,6 +11,7 @@ import {take} from 'rxjs/operators';
 import {
   SearchDisplay
 } from '../complex/complex-results/complex-navigator/service/state/complex-navigator-display.service';
+import {ComplexNavigatorComponent} from '../complex/complex-results/complex-navigator/complex-navigator.component';
 
 
 @Component({
@@ -23,6 +24,8 @@ export class BasketComponent implements OnInit, AfterViewInit {
   complexSearchBasket: ComplexSearchResult = null;
   allInteractorsInComplexSearchBasket: Interactor[] = [];
   displayType: SearchDisplay;
+
+  @ViewChild(ComplexNavigatorComponent) navigator: ComplexNavigatorComponent;
 
   constructor(private _basketService: BasketService,
               private titleService: Title,
@@ -48,6 +51,9 @@ export class BasketComponent implements OnInit, AfterViewInit {
     if (this.displayType !== displayType) {
       this.displayType = displayType;
       this.router.navigate([], {fragment: this.displayType});
+    }
+    if (displayType === SearchDisplay.navigator) {
+      this.navigator?.adjustColWidth();
     }
   }
 

--- a/src/app/complex/complex-results/complex-navigator/complex-navigator.component.html
+++ b/src/app/complex/complex-results/complex-navigator/complex-navigator.component.html
@@ -1,7 +1,7 @@
 <div class="ComplexNavigator"
-     [style.--cols]="complexSearch().elements.length"
      [class.horizontal]="complexSearch().elements.length <= 6"
      [class.sorted]="isSorted()"
+     [style.--cols]="state.numberOfColumns()"
      [style.--colSize.px]="state.columnWidth()"
      [style.--sizeSpaceHolder.px]="state.spaceHolderWidth()"
 >

--- a/src/app/complex/complex-results/complex-navigator/complex-navigator.component.html
+++ b/src/app/complex/complex-results/complex-navigator/complex-navigator.component.html
@@ -1,9 +1,11 @@
-<div class="ComplexNavigator"
+<div class="ComplexNavigator" #parent
      [class.horizontal]="complexSearch().elements.length <= 6"
      [class.sorted]="isSorted()"
-     [style.--cols]="state.numberOfColumns()"
+     [style.--cols]="numberOfColumns()"
      [style.--colSize.px]="state.columnWidth()"
      [style.--sizeSpaceHolder.px]="state.spaceHolderWidth()"
+     [style.--intHeader.px]="interactorWidth()"
+     [style.--sortingGroupSize.px]="sortingWidth()"
 >
 
   <div class="buttons">

--- a/src/app/complex/complex-results/complex-navigator/complex-navigator.component.html
+++ b/src/app/complex/complex-results/complex-navigator/complex-navigator.component.html
@@ -1,11 +1,12 @@
 <div class="ComplexNavigator" #parent
      [class.horizontal]="complexSearch().elements.length <= 6"
-     [class.sorted]="isSorted()"
+     [class.sorted]="state.isSorted()"
      [style.--cols]="numberOfColumns()"
      [style.--colSize.px]="state.columnWidth()"
      [style.--sizeSpaceHolder.px]="state.spaceHolderWidth()"
-     [style.--intHeader.px]="interactorWidth()"
-     [style.--sortingGroupSize.px]="sortingWidth()"
+     [style.--sortingGroupSize.px]="state.sortingWidth()"
+     [style.--componentSize.px]="state.interactorWidth()"
+     [style.--intHeader.px]="state.interactorHeaderWidth()"
 >
 
   <div class="buttons">

--- a/src/app/complex/complex-results/complex-navigator/complex-navigator.component.html
+++ b/src/app/complex/complex-results/complex-navigator/complex-navigator.component.html
@@ -1,7 +1,11 @@
 <div class="ComplexNavigator"
      [style.--cols]="complexSearch().elements.length"
      [class.horizontal]="complexSearch().elements.length <= 6"
-     [class.sorted]="isSorted()">
+     [class.sorted]="isSorted()"
+     [style.--colSize.px]="state.columnWidth()"
+     [style.--sizeSpaceHolder.px]="state.spaceHolderWidth()"
+>
+
   <div class="buttons">
     <cp-complex-navigator-buttons [orthologsGroupsAvailable]="orthologGroupsAvailable()"/>
   </div>

--- a/src/app/complex/complex-results/complex-navigator/complex-navigator.component.scss
+++ b/src/app/complex/complex-results/complex-navigator/complex-navigator.component.scss
@@ -5,16 +5,11 @@
   --colSize: 70px;
   --intHeader: calc(var(--componentSize) + var(--sortingGroupSize));
   --totalWidth: calc(var(--intHeader) + var(--cols) * var(--colSize) + var(--sizeSpaceHolder));
-  max-width: var(--totalWidth);
 
   margin: auto;
 
   &.horizontal {
     max-width: none;
-  }
-
-  &.sorted {
-    --sortingGroupSize: 3ch;
   }
 
 }

--- a/src/app/complex/complex-results/complex-navigator/complex-navigator.component.scss
+++ b/src/app/complex/complex-results/complex-navigator/complex-navigator.component.scss
@@ -3,7 +3,6 @@
   --componentSize: 230px;
   --sortingGroupSize: 0px;
   --colSize: 70px;
-  --sizeSpaceHolder: 185px;
   --intHeader: calc(var(--componentSize) + var(--sortingGroupSize));
   --totalWidth: calc(var(--intHeader) + var(--cols) * var(--colSize) + var(--sizeSpaceHolder));
   max-width: var(--totalWidth);

--- a/src/app/complex/complex-results/complex-navigator/complex-navigator.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/complex-navigator.component.ts
@@ -28,16 +28,12 @@ export class ComplexNavigatorComponent implements AfterViewInit {
   navigatorComponentsWithoutGrouping = computed(() => this.createNavigatorComplexes(this.complexSearch().elements, this.interactors()));
   navigatorComponentsGroupedByOrthologs = computed(() => this.createOrthologGroups(this.navigatorComponentsWithoutGrouping()));
   orthologGroupsAvailable = computed(() => this.navigatorComponentsGroupedByOrthologs().some(c => c instanceof NavigatorOrthologGroup));
-  isSorted = computed(() => this.state.componentsSorting() !== NavigatorComponentSorting.DEFAULT);
-
-  sortingWidth = computed(() => this.isSorted() ? 20 : 0);
-  interactorWidth = computed(() => 230 + this.sortingWidth());
 
   @ViewChild('parent') parent: ElementRef<HTMLDivElement>;
   navigatorComponents: INavigatorComponent[] = [];
 
   constructor(private complexPortalService: ComplexPortalService, public state: NavigatorStateService) {
-    effect(() => this.numberOfColumns() && this.adjustColWidth(), {allowSignalWrites: true});
+    effect(() => this.adjustColWidth(), {allowSignalWrites: true});
     effect(() => this.setNavigatorComponents(this.navigatorComponentsGroupedByOrthologs(), this.navigatorComponentsWithoutGrouping()));
   }
 
@@ -47,15 +43,7 @@ export class ComplexNavigatorComponent implements AfterViewInit {
 
   @HostListener('window:resize', ['$event'])
   adjustColWidth() {
-    setTimeout(() => {
-      const total = this.parent.nativeElement.clientWidth;
-      this.state.columnWidth.set(
-        Math.max(
-          (total - this.interactorWidth() - this.state.spaceHolderWidth()) / this.numberOfColumns(),
-          70
-        )
-      );
-    });
+    this.state.adjustColumnWidth(this.parent.nativeElement.clientWidth, this.numberOfColumns());
   }
 
   private setNavigatorComponents(navigatorComponentsGroupedByOrthologs: INavigatorComponent[],

--- a/src/app/complex/complex-results/complex-navigator/complex-navigator.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/complex-navigator.component.ts
@@ -31,7 +31,7 @@ export class ComplexNavigatorComponent {
   isSorted = computed(() => this.state.componentsSorting() !== NavigatorComponentSorting.DEFAULT);
   navigatorComponents: INavigatorComponent[] = [];
 
-  constructor(private complexPortalService: ComplexPortalService, private state: NavigatorStateService) {
+  constructor(private complexPortalService: ComplexPortalService, public state: NavigatorStateService) {
     effect(() => {
       this.setNavigatorComponents(this.navigatorComponentsGroupedByOrthologs(), this.navigatorComponentsWithoutGrouping());
     });

--- a/src/app/complex/complex-results/complex-navigator/complex-navigator.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/complex-navigator.component.ts
@@ -30,9 +30,8 @@ export class ComplexNavigatorComponent {
   navigatorComponents: INavigatorComponent[] = [];
 
   constructor(private complexPortalService: ComplexPortalService, public state: NavigatorStateService) {
-    effect(() => {
-      this.setNavigatorComponents(this.navigatorComponentsGroupedByOrthologs(), this.navigatorComponentsWithoutGrouping());
-    });
+    effect(() => this.state.numberOfColumns.set(this.complexSearch().elements.length), {allowSignalWrites: true});
+    effect(() => this.setNavigatorComponents(this.navigatorComponentsGroupedByOrthologs(), this.navigatorComponentsWithoutGrouping()));
   }
 
   private setNavigatorComponents(navigatorComponentsGroupedByOrthologs: INavigatorComponent[],

--- a/src/app/complex/complex-results/complex-navigator/complex-navigator.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/complex-navigator.component.ts
@@ -1,4 +1,4 @@
-import {Component, computed, effect, input, output} from '@angular/core';
+import {AfterViewInit, Component, computed, effect, ElementRef, HostListener, input, output, ViewChild} from '@angular/core';
 import {ComplexSearchResult} from '../../shared/model/complex-results/complex-search.model';
 import {Interactor} from '../../shared/model/complex-results/interactor.model';
 import {Complex} from '../../shared/model/complex-results/complex.model';
@@ -17,21 +17,45 @@ import {NavigatorComponentSorting, NavigatorStateService} from './service/state/
   styleUrls: ['./complex-navigator.component.scss']
 })
 
-export class ComplexNavigatorComponent {
+export class ComplexNavigatorComponent implements AfterViewInit {
   complexSearch = input<ComplexSearchResult>();
   interactors = input<Interactor[]>();
   onComplexRemovedFromBasket = output<string>();
+
   anyChange = output<void>();
 
+  numberOfColumns = computed(() => this.complexSearch().elements.length);
   navigatorComponentsWithoutGrouping = computed(() => this.createNavigatorComplexes(this.complexSearch().elements, this.interactors()));
   navigatorComponentsGroupedByOrthologs = computed(() => this.createOrthologGroups(this.navigatorComponentsWithoutGrouping()));
   orthologGroupsAvailable = computed(() => this.navigatorComponentsGroupedByOrthologs().some(c => c instanceof NavigatorOrthologGroup));
   isSorted = computed(() => this.state.componentsSorting() !== NavigatorComponentSorting.DEFAULT);
+
+  sortingWidth = computed(() => this.isSorted() ? 20 : 0);
+  interactorWidth = computed(() => 230 + this.sortingWidth());
+
+  @ViewChild('parent') parent: ElementRef<HTMLDivElement>;
   navigatorComponents: INavigatorComponent[] = [];
 
   constructor(private complexPortalService: ComplexPortalService, public state: NavigatorStateService) {
-    effect(() => this.state.numberOfColumns.set(this.complexSearch().elements.length), {allowSignalWrites: true});
+    effect(() => this.numberOfColumns() && this.adjustColWidth(), {allowSignalWrites: true});
     effect(() => this.setNavigatorComponents(this.navigatorComponentsGroupedByOrthologs(), this.navigatorComponentsWithoutGrouping()));
+  }
+
+  ngAfterViewInit(): void {
+    this.adjustColWidth();
+  }
+
+  @HostListener('window:resize', ['$event'])
+  adjustColWidth() {
+    setTimeout(() => {
+      const total = this.parent.nativeElement.clientWidth;
+      this.state.columnWidth.set(
+        Math.max(
+          (total - this.interactorWidth() - this.state.spaceHolderWidth()) / this.numberOfColumns(),
+          70
+        )
+      );
+    });
   }
 
   private setNavigatorComponents(navigatorComponentsGroupedByOrthologs: INavigatorComponent[],

--- a/src/app/complex/complex-results/complex-navigator/service/state/complex-navigator-display.service.ts
+++ b/src/app/complex/complex-results/complex-navigator/service/state/complex-navigator-display.service.ts
@@ -91,33 +91,15 @@ export class NavigatorStateService {
    */
 
   /**
-   * Number of columns in the complex navigator.
-   */
-  numberOfColumns = model<number>(20);
-  /**
    * Angle of headers when more than 6 columns, in deg
    */
   angle = model<number>(45);
-  /**
-   * Minimum width to use for the columns, in px.
-   * This is to make that with a large number of columns, columns are still wise enough to be readable.
-   */
-  minColumnWidth = model<number>(70);
-  /**
-   * Used to calculate the total width, assuming a maximum number of columns of 20.
-   * This is true on the search results, but not on the basket.
-   */
-  maxNumberOfColumns = model<number>(20);
-  /**
-   * The total width of all columns, meaning the width of the complex navigator excluding the header column.
-   * We calculate this for 20 columns (max number of columns), each with 70px width (min width).
-   */
-  totalColumnWidth = computed(() => this.minColumnWidth() * this.maxNumberOfColumns());
+
   /**
    * Width of a single column of complex when more than 6 columns, in px.
    * This is calculated based on the total width and the number of columns.
    */
-  columnWidth = computed(() => Math.max(this.totalColumnWidth() / this.numberOfColumns(), this.minColumnWidth()));
+  columnWidth = model<number>(70);
   /**
    * Height of the displayed part of the tilted headers after rotation, in px
    */

--- a/src/app/complex/complex-results/complex-navigator/service/state/complex-navigator-display.service.ts
+++ b/src/app/complex/complex-results/complex-navigator/service/state/complex-navigator-display.service.ts
@@ -91,13 +91,33 @@ export class NavigatorStateService {
    */
 
   /**
+   * Number of columns in the complex navigator.
+   */
+  numberOfColumns = model<number>(20);
+  /**
    * Angle of headers when more than 6 columns, in deg
    */
   angle = model<number>(45);
   /**
-   * Width of a single column of complex when more than 6 columns, in px
+   * Minimum width to use for the columns, in px.
+   * This is to make that with a large number of columns, columns are still wise enough to be readable.
    */
-  columnWidth = model<number>(70);
+  minColumnWidth = model<number>(70);
+  /**
+   * Used to calculate the total width, assuming a maximum number of columns of 20.
+   * This is true on the search results, but not on the basket.
+   */
+  maxNumberOfColumns = model<number>(20);
+  /**
+   * The total width of all columns, meaning the width of the complex navigator excluding the header column.
+   * We calculate this for 20 columns (max number of columns), each with 70px width (min width).
+   */
+  totalColumnWidth = computed(() => this.minColumnWidth() * this.maxNumberOfColumns());
+  /**
+   * Width of a single column of complex when more than 6 columns, in px.
+   * This is calculated based on the total width and the number of columns.
+   */
+  columnWidth = computed(() => Math.max(this.totalColumnWidth() / this.numberOfColumns(), this.minColumnWidth()));
   /**
    * Height of the displayed part of the tilted headers after rotation, in px
    */

--- a/src/app/complex/complex-results/complex-navigator/service/state/complex-navigator-display.service.ts
+++ b/src/app/complex/complex-results/complex-navigator/service/state/complex-navigator-display.service.ts
@@ -1,4 +1,4 @@
-import {computed, effect, Injectable, model, ModelSignal} from '@angular/core';
+import {computed, effect, Injectable, input, model, ModelSignal} from '@angular/core';
 import {ActivatedRoute, Router} from '@angular/router';
 
 export enum NavigatorComponentSorting {
@@ -36,6 +36,30 @@ export class NavigatorStateService {
   }));
 
   ignore = false;
+
+  /**
+   * Angle of headers when more than 6 columns, in deg
+   */
+  angle = model<number>(45);
+  /**
+   * Width of a single column of complex when more than 6 columns, in px
+   */
+  columnWidth = model<number>(70);
+  /**
+   * Height of the displayed part of the tilted headers after rotation, in px
+   */
+  displayedHeight = model<number>(200);
+
+
+  _angleRad = computed(() => this.angle() * Math.PI / 180);
+  transform = computed(() => `rotate(${this.angle()}deg) translateX(1px)`);
+  /**
+   * Explanations on https://www.geogebra.org/calculator/jtx3rcs4
+   */
+  opposite = computed(() => this.columnWidth() * Math.sin(this._angleRad()));
+  adjacent = computed(() => this.columnWidth() * Math.cos(this._angleRad()));
+  contentHeight = computed(() => this.displayedHeight() / Math.cos(this._angleRad()) + this.opposite());
+  spaceHolderWidth = computed(() => this.displayedHeight() * Math.tan(this._angleRad()));
 
   constructor(private route: ActivatedRoute, private router: Router) {
     this.route.queryParams.subscribe(queryParams => {

--- a/src/app/complex/complex-results/complex-navigator/service/state/complex-navigator-display.service.ts
+++ b/src/app/complex/complex-results/complex-navigator/service/state/complex-navigator-display.service.ts
@@ -86,6 +86,20 @@ export class NavigatorStateService {
     }
   }
 
+  interactorWidth = model<number>(230);
+  isSorted = computed(() => this.componentsSorting() !== NavigatorComponentSorting.DEFAULT);
+  sortingWidth = computed(() => this.isSorted() ? 20 : 0);
+  interactorHeaderWidth = computed(() => this.interactorWidth() + this.sortingWidth());
+
+  adjustColumnWidth(totalComponentWidth: number, numberOfColumns: number) {
+    this.columnWidth.set(
+      Math.max(
+        (totalComponentWidth - this.interactorHeaderWidth() - this.spaceHolderWidth()) / numberOfColumns,
+        70
+      )
+    );
+  }
+
   /* TILTED HEADER STATS
    * Explanations on https://www.geogebra.org/calculator/jtx3rcs4
    */

--- a/src/app/complex/complex-results/complex-navigator/service/state/complex-navigator-display.service.ts
+++ b/src/app/complex/complex-results/complex-navigator/service/state/complex-navigator-display.service.ts
@@ -37,30 +37,6 @@ export class NavigatorStateService {
 
   ignore = false;
 
-  /**
-   * Angle of headers when more than 6 columns, in deg
-   */
-  angle = model<number>(45);
-  /**
-   * Width of a single column of complex when more than 6 columns, in px
-   */
-  columnWidth = model<number>(70);
-  /**
-   * Height of the displayed part of the tilted headers after rotation, in px
-   */
-  displayedHeight = model<number>(200);
-
-
-  _angleRad = computed(() => this.angle() * Math.PI / 180);
-  transform = computed(() => `rotate(${this.angle()}deg) translateX(1px)`);
-  /**
-   * Explanations on https://www.geogebra.org/calculator/jtx3rcs4
-   */
-  opposite = computed(() => this.columnWidth() * Math.sin(this._angleRad()));
-  adjacent = computed(() => this.columnWidth() * Math.cos(this._angleRad()));
-  contentHeight = computed(() => this.displayedHeight() / Math.cos(this._angleRad()) + this.opposite());
-  spaceHolderWidth = computed(() => this.displayedHeight() * Math.tan(this._angleRad()));
-
   constructor(private route: ActivatedRoute, private router: Router) {
     this.route.queryParams.subscribe(queryParams => {
       const paramKeys = Object.keys(this.params());
@@ -109,4 +85,54 @@ export class NavigatorStateService {
         return paramValue;
     }
   }
+
+  /* TILTED HEADER STATS
+   * Explanations on https://www.geogebra.org/calculator/jtx3rcs4
+   */
+
+  /**
+   * Angle of headers when more than 6 columns, in deg
+   */
+  angle = model<number>(45);
+  /**
+   * Width of a single column of complex when more than 6 columns, in px
+   */
+  columnWidth = model<number>(70);
+  /**
+   * Height of the displayed part of the tilted headers after rotation, in px
+   */
+  displayedHeight = model<number>(200);
+
+  /**
+   * JS trigo function are working in rad, so we need to convert them into rad
+   */
+  _angleRad = computed(() => this.angle() * Math.PI / 180);
+  /**
+   * For some reason the upper header is shifted by one pixel left to the rest of the table.
+   * This translateX fix that.
+   * The rotate is the real important bit
+   */
+  transform = computed(() => `translateX(1px) rotate(${this.angle()}deg)`);
+  /**
+   * Length of the right side of the hidden triangle after rotation.<br>
+   * Used to know the real height of the inner element, and to place padding.<br>
+   * Illustration at https://www.geogebra.org/calculator/jtx3rcs4
+   */
+  opposite = computed(() => this.columnWidth() * Math.sin(this._angleRad()));
+  /**
+   * Length of the left side of the hidden triangle after rotation.<br>
+   * Used to know the width of the inner element<br>
+   * Illustration at https://www.geogebra.org/calculator/jtx3rcs4
+   */
+  adjacent = computed(() => this.columnWidth() * Math.cos(this._angleRad()));
+  /**
+   * Real height of the inner element.<br>
+   * Illustration at https://www.geogebra.org/calculator/jtx3rcs4
+   */
+  contentHeight = computed(() => this.displayedHeight() / Math.cos(this._angleRad()) + this.opposite());
+  /**
+   * Width of the slope, used for the terminal placeholder.<br>
+   * Illustration at https://www.geogebra.org/calculator/jtx3rcs4
+   */
+  spaceHolderWidth = computed(() => this.displayedHeight() * Math.tan(this._angleRad()));
 }

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.html
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.html
@@ -44,16 +44,22 @@
     <!-- When table is overflowing -->
     @if (complexes().length > 6) {
       <thead class="tableHeadOverflow">
-      <tr>
+      <tr class="rotate">
         <th class="spaceHolderHeaderOverflow">
-            <div class="shadow right" [class.visible]="shadowVisible()"></div>
+          <div class="shadow right" [class.visible]="shadowVisible()"></div>
         </th>
         @for (complex of complexes(); track complex.complexAC) {
           <th class="rotate"
+              [style.transform]="state.transform()"
+              [style.height.px]="state.displayedHeight()"
+              [style.width.px]="state.adjacent()"
               [class.predicted]="complex.predictedComplex">
-            <a [routerLink]="['/complex', complex.complexAC]"
-               [matTooltip]="complex.complexName+ ' - '+ complex.complexAC"
-               target="_blank">
+            <a [style.height.px]="state.contentHeight()"
+               [style.padding-top.px]="state.opposite() / 2"
+               [style.padding-bottom.px]="state.opposite() / 2"
+              [routerLink]="['/complex', complex.complexAC]"
+              [matTooltip]="complex.complexName+ ' - '+ complex.complexAC"
+              target="_blank">
               <div>
                   <span>
                     <div class="tilted-label">
@@ -65,7 +71,11 @@
             </a>
           </th>
         }
-        <div class="spaceHolder" [class.predicted]="anyPredictedComplex()"></div>
+        <th class="spaceHolder" [style.width.px]="state.spaceHolderWidth()" [style.height.px]="state.displayedHeight()" [class.predicted]="anyPredictedComplex()">
+          <svg style="width: 100%; height: 100%" viewBox="0 0 100 100" preserveAspectRatio="none">
+            <polygon points="0,100 100,100 100,0" fill="blue" style="fill: var(--primary)" />
+          </svg>
+        </th>
       </tr>
       <!-- icons row -->
       <tr>
@@ -98,7 +108,7 @@
             </div>
           </th>
         }
-        <div class="spaceHolder" [class.predicted]="anyPredictedComplex()"></div>
+        <div class="spaceHolder primary" [class.predicted]="anyPredictedComplex()"></div>
       </tr>
       </thead>
     }

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.html
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.html
@@ -108,7 +108,7 @@
             </div>
           </th>
         }
-        <div class="spaceHolder primary" [class.predicted]="anyPredictedComplex()"></div>
+        <th class="spaceHolder primary" [class.predicted]="anyPredictedComplex()"></th>
       </tr>
       </thead>
     }

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.scss
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.scss
@@ -45,7 +45,7 @@ thead {
   tr {
     --parentWidth: 100%;
     display: grid;
-    grid-template-columns: var(--intHeader) repeat(auto-fit, var(--colSize));
+    grid-template-columns: var(--intHeader) repeat(var(--cols), var(--colSize)) var(--sizeSpaceHolder);
     width: var(--totalWidth);
 
     &.rotate {
@@ -107,8 +107,7 @@ thead {
   left: 0;
   z-index: 4;
   background-color: var(--on-primary);
-  height: 60px;
-  line-height: var(--colSize);
+  align-content: end;
   text-align: right;
   color: var(--primary);
   padding: 5px;

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.scss
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.scss
@@ -21,7 +21,6 @@ thead {
   z-index: 4;
   color: var(--primary);
   background-color: var(--on-primary);
-  padding-top: 173px;
   text-align: right;
 }
 
@@ -37,7 +36,6 @@ thead {
 
 .tilted-label {
   text-overflow: ellipsis;
-  width: 28ch;
   white-space: nowrap;
   overflow: hidden;
 }
@@ -49,40 +47,56 @@ thead {
     display: grid;
     grid-template-columns: var(--intHeader) repeat(auto-fit, var(--colSize));
     width: var(--totalWidth);
-  }
 
-  th.rotate {
-    position: relative;
-    width: 338px;
-    height: 51px !important;
-    color: var(--on-primary);
-    font-size: 14px;
-    text-align: left;
-    border: 1px solid white;
-    top: 76px;
-    left: -52px;
-    display: flex;
-    align-items: center;
-    align-content: center;
-    padding: 0;
-    transform: rotate(-45deg);
-    border-collapse: collapse;
+    &.rotate {
+      overflow: clip;
 
-    a {
-      width: 100%;
-      height: 100%;
-      align-content: center;
-      background-color: var(--primary);
-      padding: 0 0 0 var(--colSize);
-      border: none;
+
+      th.rotate {
+        position: relative;
+        color: var(--on-primary);
+        font-size: 14px;
+        text-align: left;
+        border-right: 1px solid white;
+        display: flex;
+        align-items: flex-end;
+        align-content: flex-end;
+        justify-content: center;
+        padding: 0;
+        transform-origin: 0 100%;
+        border-collapse: collapse;
+
+        > * {
+          align-content: center;
+          background-color: var(--primary);
+          width: 100%;
+          border: none;
+          writing-mode: vertical-rl;
+          transform: rotate(180deg); // Make label bottom to top
+
+          > * {
+            transform: translate(5px, 2px); // Make label icon aligned to other icons
+          }
+        }
+      }
+
     }
   }
 }
 
 .spaceHolder {
   width: var(--sizeSpaceHolder);
-  background-color: var(--primary);
+  //background-color: var(--primary);
   border-left: 1px solid white;
+  padding: 0;
+  pointer-events: none;
+  &.primary {
+    background: var(--primary)
+  }
+
+  svg {
+    transform: translateY(1px);
+  }
 }
 
 .interactorsHeader {

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-header/table-header.component.ts
@@ -11,15 +11,14 @@ import {NavigatorComponentSorting, NavigatorStateService} from '../../service/st
 })
 
 export class TableHeaderComponent {
-  complexes = input<Complex[]>();
+  complexes = input.required<Complex[]>();
   onComplexRemovedFromBasket = output<string>();
 
   shadowVisible = input<boolean>(false);
 
-  constructor(private basketService: BasketService, private state: NavigatorStateService) {
+  constructor(private basketService: BasketService, public state: NavigatorStateService) {
   }
 
-  isSorted = computed(() => this.state.componentsSorting() !== NavigatorComponentSorting.DEFAULT);
 
   anyPredictedComplex(): boolean {
     return this.complexes().some(c => c.predictedComplex);

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.html
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.html
@@ -3,7 +3,7 @@
          [ngClass]="{'inheritedWidth': complexes().length > 6}">
     @for (interactor of navigatorComponents(); track i; let i = $index) {
       @if (!interactor.hidden) {
-        <tr [class.ortholog]="!!interactor.isOrthologGroup && state.mergeOrthologs">
+        <tr [class.ortholog]="!!interactor.isOrthologGroup && state.mergeOrthologs()">
           @for (range of ranges; track range.value) {
             @if (range.start === i) {
               <td [attr.rowspan]="range.length" class="interactorSeparation"
@@ -57,7 +57,7 @@
             <tr
               class="expandedRows"
               [ngClass]="getExpandedRowClass(j, interactor.subComponents.length)">
-              @if (j === 0 && isSorting()) {
+              @if (j === 0 && state.isSorted()) {
                 <td [attr.rowspan]="interactor.subComponents.length" class="interactorSeparation"
                     [matTooltip]="interactor.expandTooltip"
                 >
@@ -66,8 +66,7 @@
                   </div>
                 </td>
               }
-              <td class="subComponentColumn"
-                  [style]="ranges.length!=0 ? 'left:3ch':''">
+              <td class="subComponentColumn" [style.left.px]="state.sortingWidth()">
                 <div>
                   <cp-table-interactor-name [interactor]="subComponent"/>
                 </div>

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-interactor-column/table-interactor-column.component.ts
@@ -24,7 +24,6 @@ export class TableInteractorColumnComponent {
   navigatorComponents = input<INavigatorComponent[]>();
   shadowVisible = input<boolean>(false);
 
-  isSorting = computed(() => this.state.componentsSorting() !== NavigatorComponentSorting.DEFAULT);
   isOrganismSorting = computed(() => this.state.componentsSorting() === NavigatorComponentSorting.ORGANISM);
 
   navigatorComplexes: NavigatorComplex[];

--- a/src/app/complex/complex-results/complex-navigator/table-structure/table-structure.component.ts
+++ b/src/app/complex/complex-results/complex-navigator/table-structure/table-structure.component.ts
@@ -38,7 +38,7 @@ export class TableStructureComponent implements AfterViewInit {
   ngAfterViewInit(): void {
     const header = this.headerDiv.nativeElement;
     this.setHorizontalShadowVisibility(header);
-    window.addEventListener('scroll', () => this.shadowTopVisible = header.getBoundingClientRect().top === this.scrollStart());
+    window.addEventListener('scroll', () => this.shadowTopVisible = header.getBoundingClientRect().top <= this.scrollStart());
   }
 
   private calculateSimilarity(complex1: Complex, complex2: Complex, navigatorComponents: INavigatorComponent[]) {

--- a/src/app/complex/complex-results/complex-results.component.html
+++ b/src/app/complex/complex-results/complex-results.component.html
@@ -33,8 +33,8 @@
               </cp-complex-paginator>
 
               <mat-tab-group [selectedIndex]="isDisplayComplexNavigatorView() ? 1 : 0"
-                             (selectedTabChange)="onTabChange($event, list, navigatorTab)">
-                <mat-tab label="List view" #list>
+                             (selectedTabChange)="onTabChange($event, listTab, navigatorTab)">
+                <mat-tab label="List view" #listTab>
                   <cp-complex-list [complexSearch]="complexSearch"/>
                 </mat-tab>
                 <mat-tab label="Navigator view" #navigatorTab>

--- a/src/app/complex/complex-results/complex-results.component.html
+++ b/src/app/complex/complex-results/complex-results.component.html
@@ -40,7 +40,7 @@
                 <mat-tab label="Navigator view" #navigatorTab>
                   <div class="ComplexNavigator"
                        [ngClass]="complexSearch.totalNumberOfResults <=6 ? 'smallCN' : 'largeCN'">
-                    <cp-complex-navigator class="Complex-navigator" #navigator
+                    <cp-complex-navigator class="Complex-navigator"
                                           [complexSearch]="complexSearch"
                                           [interactors]="allInteractorsInComplexSearch"
                                           (anyChange)="reloadPage()">

--- a/src/app/complex/complex-results/complex-results.component.html
+++ b/src/app/complex/complex-results/complex-results.component.html
@@ -33,14 +33,14 @@
               </cp-complex-paginator>
 
               <mat-tab-group [selectedIndex]="isDisplayComplexNavigatorView() ? 1 : 0"
-                             (selectedTabChange)="onTabChange($event, list, navigator)">
+                             (selectedTabChange)="onTabChange($event, list, navigatorTab)">
                 <mat-tab label="List view" #list>
                   <cp-complex-list [complexSearch]="complexSearch"/>
                 </mat-tab>
-                <mat-tab label="Navigator view" #navigator>
+                <mat-tab label="Navigator view" #navigatorTab>
                   <div class="ComplexNavigator"
                        [ngClass]="complexSearch.totalNumberOfResults <=6 ? 'smallCN' : 'largeCN'">
-                    <cp-complex-navigator class="Complex-navigator"
+                    <cp-complex-navigator class="Complex-navigator" #navigator
                                           [complexSearch]="complexSearch"
                                           [interactors]="allInteractorsInComplexSearch"
                                           (anyChange)="reloadPage()">

--- a/src/app/complex/complex-results/complex-results.component.ts
+++ b/src/app/complex/complex-results/complex-results.component.ts
@@ -1,4 +1,4 @@
-import {AfterViewInit, Component, effect, OnInit} from '@angular/core';
+import {AfterViewInit, Component, effect, OnInit, ViewChild} from '@angular/core';
 import {ActivatedRoute, NavigationExtras, Params, Router} from '@angular/router';
 import {ComplexSearchResult} from '../shared/model/complex-results/complex-search.model';
 import {ComplexPortalService} from '../shared/service/complex-portal.service';
@@ -9,6 +9,7 @@ import {Interactor} from '../shared/model/complex-results/interactor.model';
 import {NotificationService} from '../../shared/notification/service/notification.service';
 import {NavigatorStateService, SearchDisplay} from './complex-navigator/service/state/complex-navigator-display.service';
 import {MatTab, MatTabChangeEvent} from '@angular/material/tabs';
+import {ComplexNavigatorComponent} from './complex-navigator/complex-navigator.component';
 
 @Component({
   selector: 'cp-complex-results',
@@ -34,6 +35,8 @@ export class ComplexResultsComponent implements OnInit, AfterViewInit {
   pageSize = 20;
   currentPageIndex: number;
   lastPageIndex: number;
+
+  @ViewChild(ComplexNavigatorComponent) navigator: ComplexNavigatorComponent;
 
   constructor(private route: ActivatedRoute, private router: Router, private state: NavigatorStateService,
               private complexPortalService: ComplexPortalService, private titleService: Title,
@@ -157,6 +160,7 @@ export class ComplexResultsComponent implements OnInit, AfterViewInit {
     }
     if (event.tab === navigator) {
       this.setComplexNavigatorView();
+      this.navigator.adjustColWidth();
     }
   }
 


### PR DESCRIPTION
Make the rotation based on the angle, the width of a column, and the visible height of a column header. 

This enables the filling of space available by the navigator, but it has not been implemented yet.

I've made the choice to perform the calculation in js instead of using css variables as their values are being evaluated at usage, and not at declaration, meaing that we would be calculating many many time trigonometric functions if we are using css variables. Unfortunately, using js makes it less easy to play with params, and will make the calculation of the desired column width slightly harder.

On the bonus side, I've also fixed the spaceholder at the end of the line so that all columns behave the same on hover